### PR TITLE
Declaration of ConcatOperator::compile() should be compatible with Logic...

### DIFF
--- a/Library/Operators/Other/ConcatOperator.php
+++ b/Library/Operators/Other/ConcatOperator.php
@@ -20,7 +20,7 @@
 class ConcatOperator extends LogicalBaseOperator
 {
 
-	public function compile($expression, $compilationContext)
+	public function compile($expression, CompilationContext $compilationContext)
 	{
 
 		if (!isset($expression['left'])) {


### PR DESCRIPTION
Declaration of ConcatOperator::compile() should be compatible with LogicalBaseOperator::compile($expression, CompilationContext $compilationContext) in zephir/Library/Operators/Other/ConcatOperator.php on line 63
