### PR TITLE
Set ZEPHIRDIR to zephir shell script's parent directory if ZEPHIRDIR ENV variable is not set.

### DIFF
--- a/bin/zephir
+++ b/bin/zephir
@@ -1,6 +1,12 @@
 #!/bin/bash
+CURDIR=`dirname $0`
+PARENTDIR=`dirname $CURDIR`
 if [ -z "$ZEPHIRDIR" ]; then
-	echo "Environment variable ZEPHIRDIR is not set"
-	exit 1
+	if [ -f $PARENTDIR/compiler.php ]; then
+		export ZEPHIRDIR=$PARENTDIR
+	else
+		echo "Environment variable ZEPHIRDIR is not set"
+		exit 1
+	fi
 fi
 php $ZEPHIRDIR/compiler.php $*


### PR DESCRIPTION
Auto set ZEPHIRDIR ENV variable to zephir shell script's parent directory if ZEPHIRDIR is not set.

Signed-off-by: Rack Lin racklin@gmail.com
