### PR TITLE
Fix critical memory bug - Fix detecting null params - Added empty array as default param

### DIFF
--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -493,6 +493,7 @@ class ClassMethod
 			$containerCode = str_replace('RETURN_MM_FALSE', 'RETURN_FALSE', $containerCode);
 			$containerCode = str_replace('RETURN_MM_EMPTY_STRING', 'RETURN_MM_EMPTY_STRING', $containerCode);
 			$containerCode = str_replace('RETURN_MM_EMPTY_ARRAY', 'RETURN_EMPTY_ARRAY', $containerCode);
+			$containerCode = str_replace('RETURN_MM_MEMBER', 'RETURN_MEMBER', $containerCode);
 			$containerCode = str_replace('RETURN_MM()', 'return', $containerCode);
 			$containerCode = preg_replace('/[ \t]+ZEPHIR_MM_RESTORE\(\);' . PHP_EOL . '/s', '', $containerCode);
 		}
@@ -620,6 +621,12 @@ class ClassMethod
 							$compilationContext->headersManager->add('kernel/memory');
 							$code .= "\t\t" . 'ZEPHIR_CPY_WRT(' . $parameter['name'] . ', ZEPHIR_GLOBAL(global_null));' . PHP_EOL;
 						}
+						break;
+					case 'empty-array':
+						$compilationContext->symbolTable->mustGrownStack(true);
+						$compilationContext->headersManager->add('kernel/memory');
+						$code .= "\t\t" . 'ZEPHIR_INIT_VAR(' . $parameter['name'] . ');' . PHP_EOL;
+						$code .= "\t\t" . 'array_init(' . $parameter['name'] . ');' . PHP_EOL;
 						break;
 					default:
 						throw new CompilerException("Default parameter value type: " . $parameter['default']['type'] . " cannot be assigned to variable(variable)", $parameter);
@@ -1096,7 +1103,7 @@ class ClassMethod
 				/**
 				 * Assign the default value according to the variable's type
 				 */
-				$initCode .= "\t" . 'if (!' . $name . ') {' . PHP_EOL;
+				$initCode .= "\t" . 'if (!' . $name . ' || Z_TYPE_P('. $name .') == IS_NULL) {' . PHP_EOL;
 				$initCode .= $this->assignDefaultValue($parameter, $compilationContext);
 				if ($dataType == 'variable') {
 					$initCode .= "\t" . '}' . PHP_EOL;

--- a/Library/Commands/Abstract.php
+++ b/Library/Commands/Abstract.php
@@ -24,6 +24,7 @@
  */
 abstract class CommandAbstract implements CommandInterface
 {
+	private $_parameters = null;
 
 	/**
 	 * Command provided by this command
@@ -44,6 +45,31 @@ abstract class CommandAbstract implements CommandInterface
 	 */
 	abstract public function getDescription();
 
+	/**
+	 * Returns parameter named $name if specified
+	 * on the commmand line else null
+	 * @param string $name
+	 * @return string
+	 */
+	protected function setParameter($name, $value)
+	{
+		if (!isset($this->_parameters)) {
+			$this->_parameters = array();
+		}
+		$this->_parameters[$name] = $value;
+	}
+	
+	/**
+	 * Returns parameter named $name if specified
+	 * on the commmand line else null
+	 * @param string $parameterName
+	 * @return string
+	 */
+	public function getParameter($name)
+	{
+		return (isset($this->_parameters[$name])) ? $this->_parameters[$name] : null;
+	}
+	
 	/**
 	 * Executes the command
 	 *

--- a/Library/Commands/Initialize.php
+++ b/Library/Commands/Initialize.php
@@ -24,7 +24,6 @@
  */
 class CommandInitialize extends CommandAbstract
 {
-	private $_namespace;
 	
 	/**
 	 * Command provided by this command
@@ -54,15 +53,10 @@ class CommandInitialize extends CommandAbstract
 		return 'Initializes a Zephir extension';
 	}
 
-	public function getNamespace()
-	{
-		return $this->_namespace;
-	}
-
 	public function execute(Config $config, Logger $logger)
 	{
 		if (isset($_SERVER['argv'][2])) {
-			$this->_namespace = strtolower(preg_replace('/[^0-9a-zA-Z]/', '', $_SERVER['argv'][2]));
+			$this->setParameter('namespace', strtolower(preg_replace('/[^0-9a-zA-Z]/', '', $_SERVER['argv'][2])));
 		}
 		parent::execute($config, $logger);
 	}

--- a/Library/Commands/Interface.php
+++ b/Library/Commands/Interface.php
@@ -45,6 +45,14 @@ interface CommandInterface
 	public function getDescription();
 
 	/**
+	 * Returns parameter named parameterName if specified
+	 * on the commmand line else null
+	 * @param string $parameterName
+	 * @return string
+	 */
+	public function getParameter($parameterName);
+
+	/**
 	 * Executes the command
 	 *
 	 * Config $config

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -317,12 +317,12 @@ class Compiler
 	 *
 	 * @param CommandInitialize $command
 	 */
-	public function init(CommandInitialize $command)
+	public function init(CommandInterface $command)
 	{
 		/**
 		 * If init namespace is specified
 		 */
-		$namespace = $command->getNamespace();
+		$namespace = $command->getParameter('namespace');
 		if (!$namespace) {
 			throw new Exception("Cannot obtain a valid initial namespace for the project");
 		}

--- a/Library/Statements/ReturnStatement.php
+++ b/Library/Statements/ReturnStatement.php
@@ -73,7 +73,7 @@ class ReturnStatement
 							}
 
 							$compilationContext->headersManager->add('kernel/object');
-							$codePrinter->output('RETURN_MEMBER(this_ptr, "' . $property . '");');
+							$codePrinter->output('RETURN_MM_MEMBER(this_ptr, "' . $property . '");');
 							return;
 						}
 					}

--- a/ext/kernel/main.h
+++ b/ext/kernel/main.h
@@ -220,11 +220,25 @@ int zephir_fetch_parameters(int num_args TSRMLS_DC, int required_args, int optio
 	return;
 
 /**
+ * Returns a zval in an object member
+ */
+#define RETURN_MM_MEMBER(object, member_name) \
+  zephir_return_property_quick(return_value, return_value_ptr, object, SL(member_name), zend_inline_hash_func(SS(member_name)) TSRMLS_CC); \
+  RETURN_MM();
+
+/**
  * Returns a zval in an object member (quick)
  */
 #define RETURN_MEMBER_QUICK(object, member_name, key) \
  	zephir_return_property_quick(return_value, return_value_ptr, object, SL(member_name), key TSRMLS_CC); \
 	return;
+
+/**
+ * Returns a zval in an object member (quick)
+ */
+#define RETURN_MM_MEMBER_QUICK(object, member_name, key) \
+  zephir_return_property_quick(return_value, return_value_ptr, object, SL(member_name), key TSRMLS_CC); \
+  RETURN_MM();
 
 /** Return without change return_value */
 #define RETURN_MM()                 { ZEPHIR_MM_RESTORE(); return; }

--- a/parser/parser.lemon
+++ b/parser/parser.lemon
@@ -2428,6 +2428,10 @@ xx_literal_expr(R) ::= CONSTANT(I) . {
 	R = xx_ret_literal(XX_T_CONSTANT, I, status->scanner_state);
 }
 
+xx_literal_expr(R) ::= SBRACKET_OPEN SBRACKET_CLOSE . {
+  R = xx_ret_expr("empty-array", NULL, NULL, NULL, status->scanner_state);
+}
+
 xx_eval_expr(R) ::= xx_common_expr(E) . {
 	R = E;
 }


### PR DESCRIPTION
- Fix a critical memory management bug that occurs when returning a
  member from a method that needed local variables, because
  ZEPHIR_MM_GROW() was called but ZEPHIR_MM_RESTORE() was not.
- Fixed detecting when null is passed as a parameter in order to assign default value to parameter. It was working when not passing a parameter but not when passing null explicitly.
- Added empty array as possible default parameter to methods. For
  instance:
  public function mymethod(myParam = [])
- Added getParameter($name) to CommandInterface

Thanks!
