### PR TITLE
fwrite fix

### DIFF
--- a/Library/Optimizers/FunctionCall/FwriteOptimizer.php
+++ b/Library/Optimizers/FunctionCall/FwriteOptimizer.php
@@ -61,10 +61,10 @@ class FwriteOptimizer
 
 		$resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 		if ($symbolVariable) {
-			$context->codePrinter->output('zephir_fwrite(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ');');
+			$context->codePrinter->output('zephir_fwrite(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
 			return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
 		} else {
-			$context->codePrinter->output('zephir_fwrite(NULL, ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ');');
+			$context->codePrinter->output('zephir_fwrite(NULL, ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
 		}
 
 		return new CompiledExpression('null', 'null', $expression);


### PR DESCRIPTION
Hi,

As far as I understand the code, fwrite function should be used with TSRMLS_CC as it's defined with TSRMLS_DC:

```
zephir/ext/kernel/file.c:void zephir_fwrite(zval *return_value, zval *stream_zval, zval *data TSRMLS_DC)
```

This PR fixes the generation of C code but it causes segmentation fault? Any help? I believe that's one of issues in Travis' build for Phalcon 2.0:

```
/home/travis/build/phalcon/cphalcon/ext/phalcon/logger/adapter/file.c:202:2: error: too few arguments to function ‘zephir_fwrite’
./kernel/file.h:38:6: note: declared here 
```

Thanks in advance,

Kamil
