### PR TITLE
Added PregMatchOptimizer.

### DIFF
--- a/Library/Optimizers/FunctionCall/PregMatchOptimizer.php
+++ b/Library/Optimizers/FunctionCall/PregMatchOptimizer.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2014 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+ | Authors: Rack Lin <racklin@gmail.com>                                    |
+ +--------------------------------------------------------------------------+
+*/
+
+/**
+ * PregMatchOptimizer
+ *
+ * Optimizes calls to 'preg_match' using internal function
+ */
+class PregMatchOptimizer
+	extends OptimizerAbstract
+{
+	/**
+	 * @param array $expression
+	 * @param Call $call
+	 * @param CompilationContext $context
+	 * @return bool|CompiledExpression|mixed
+	 */
+	public function optimize(array $expression, Call $call, CompilationContext $context)
+	{
+		if (!isset($expression['parameters'])) {
+			return false;
+		}
+		if (count($expression['parameters']) < 2) {
+			return false;
+		}
+
+                /**
+                 * Process the matches result
+                 */
+                if (count($expression['parameters']) >= 3 && $expression['parameters'][2]['type'] == 'variable') {
+                    $matchesVariable = $context->symbolTable->getVariable($expression['parameters'][2]['value']);
+                    if (!$matchesVariable->isInitialized()) {
+                        $matchesVariable->initVariant($context);
+                        $matchesVariable->setIsInitialized(true);
+                    }
+                } else {
+                    $matchesVariable = $context->symbolTable->addTemp('variable', $context);
+                    $matchesVariable->initVariant($context);
+                }
+                $matchesVariable->setDynamicTypes('array');
+
+		/**
+		 * Process the expected symbol to be returned
+		 */
+		$call->processExpectedReturn($context);
+
+		$symbolVariable = $call->getSymbolVariable();
+                if ($symbolVariable) {
+                    if ($symbolVariable->getType() != 'variable') {
+                            throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
+                    }
+                    if ($call->mustInitSymbolVariable()) {
+                            $symbolVariable->initVariant($context);
+                    }
+                } else {
+                    $symbolVariable = $context->symbolTable->addTemp('variable', $context);
+                    $symbolVariable->initVariant($context);
+                }
+
+		$context->headersManager->add('kernel/string');
+
+		$resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+		$context->codePrinter->output('zephir_preg_match(' . $symbolVariable->getName() . ', &(' . $symbolVariable->getName() . '), ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ', ' . $matchesVariable->getName() . ' TSRMLS_CC);');
+		return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
+	}
+}

--- a/ext/config.m4
+++ b/ext/config.m4
@@ -2,6 +2,28 @@ PHP_ARG_ENABLE(test, whether to enable test, [ --enable-test   Enable Test])
 
 if test "$PHP_TEST" = "yes"; then
 	AC_DEFINE(HAVE_TEST, 1, [Whether you have Test])
-	test_sources="test.c kernel/main.c kernel/memory.c kernel/exception.c kernel/hash.c kernel/debug.c kernel/backtrace.c kernel/object.c kernel/array.c kernel/string.c kernel/fcall.c kernel/require.c kernel/alternative/fcall.c kernel/file.c kernel/operators.c kernel/concat.c test/arithmetic.c test/assign.c test/cast.c test/cblock.c test/constants.c test/constantsinterface.c test/constantsparent.c test/declare.c test/echoes.c test/emptytest.c test/exception.c test/exceptions.c test/fannkuch.c test/fcall.c test/fibonnaci.c test/flow.c test/fortytwo.c test/mcall.c test/mcallchained.c test/nativearray.c test/oo.c test/oo/ooconstruct.c test/oo/ooconstructparams.c test/oo/oodynamica.c test/oo/oodynamicb.c test/oo/oonoconstruct.c test/oo/ooparams.c test/oo/propertyaccess.c test/properties/privateproperties.c test/properties/protectedproperties.c test/properties/publicproperties.c test/regexdna.c test/returns.c test/router.c test/router/exception.c test/router/route.c test/scall.c test/scallexternal.c test/scallparent.c test/spectralnorm.c test/testinterface.c "
+	test_sources="test.c kernel/main.c kernel/memory.c kernel/exception.c kernel/hash.c kernel/debug.c kernel/backtrace.c kernel/object.c kernel/array.c kernel/string.c kernel/fcall.c kernel/require.c kernel/alternative/fcall.c kernel/file.c kernel/operators.c kernel/concat.c test/arithmetic.c test/assign.c test/cast.c test/cblock.c test/constants.c test/constantsinterface.c test/constantsparent.c test/declare.c test/echoes.c test/emptytest.c test/exception.c test/exceptions.c test/fannkuch.c test/fcall.c test/fibonnaci.c test/flow.c test/fortytwo.c test/mcall.c test/mcallchained.c test/nativearray.c test/oo.c test/oo/ooconstruct.c test/oo/ooconstructparams.c test/oo/oodynamica.c test/oo/oodynamicb.c test/oo/oonoconstruct.c test/oo/ooparams.c test/oo/propertyaccess.c test/pregmatch.c test/properties/privateproperties.c test/properties/protectedproperties.c test/properties/publicproperties.c test/regexdna.c test/returns.c test/router.c test/router/exception.c test/router/route.c test/scall.c test/scallexternal.c test/scallparent.c test/spectralnorm.c test/testinterface.c "
 	PHP_NEW_EXTENSION(test, $test_sources, $ext_shared)
+
+	old_CPPFLAGS=$CPPFLAGS
+	CPPFLAGS="$CPPFLAGS $INCLUDES"
+
+	AC_CHECK_DECL(
+		[HAVE_BUNDLED_PCRE],
+		[
+			AC_CHECK_HEADERS(
+				[ext/pcre/php_pcre.h],
+				[
+					PHP_ADD_EXTENSION_DEP([test], [pcre])
+					AC_DEFINE([ZEPHIR_USE_PHP_PCRE], [1], [Whether PHP pcre extension is present at compile time])
+				],
+				,
+				[[#include "main/php.h"]]
+			)
+		],
+		,
+		[[#include "php_config.h"]]
+	)
+
+	CPPFLAGS=$old_CPPFLAGS
 fi

--- a/ext/php_test.h
+++ b/ext/php_test.h
@@ -5,7 +5,8 @@
 
 #include "kernel/globals.h"
 
-#define PHP_TEST_VERSION "0.0.1"
+#define PHP_TEST_NAME    "Test Extension"
+#define PHP_TEST_VERSION "1.0.0"
 #define PHP_TEST_EXTNAME "test"
 
 

--- a/ext/test.c
+++ b/ext/test.c
@@ -46,6 +46,7 @@ zend_class_entry *test_oo_oodynamicb_ce;
 zend_class_entry *test_oo_oonoconstruct_ce;
 zend_class_entry *test_oo_ooparams_ce;
 zend_class_entry *test_oo_propertyaccess_ce;
+zend_class_entry *test_pregmatch_ce;
 zend_class_entry *test_properties_privateproperties_ce;
 zend_class_entry *test_properties_protectedproperties_ce;
 zend_class_entry *test_properties_publicproperties_ce;
@@ -92,6 +93,7 @@ PHP_MINIT_FUNCTION(test){
 	ZEPHIR_INIT(Test_Oo_OoNoConstruct);
 	ZEPHIR_INIT(Test_Oo_OoParams);
 	ZEPHIR_INIT(Test_Oo_PropertyAccess);
+	ZEPHIR_INIT(Test_Pregmatch);
 	ZEPHIR_INIT(Test_Properties_PrivateProperties);
 	ZEPHIR_INIT(Test_Properties_ProtectedProperties);
 	ZEPHIR_INIT(Test_Properties_PublicProperties);
@@ -162,6 +164,7 @@ static PHP_RSHUTDOWN_FUNCTION(test){
 static PHP_MINFO_FUNCTION(test)
 {
 	php_info_print_table_start();
+	php_info_print_table_header(2, PHP_TEST_NAME, "enabled");
 	php_info_print_table_row(2, "Version", PHP_TEST_VERSION);
 	php_info_print_table_end();
 }

--- a/ext/test.h
+++ b/ext/test.h
@@ -30,6 +30,7 @@
 #include "test/oo/oonoconstruct.h"
 #include "test/oo/ooparams.h"
 #include "test/oo/propertyaccess.h"
+#include "test/pregmatch.h"
 #include "test/properties/privateproperties.h"
 #include "test/properties/protectedproperties.h"
 #include "test/properties/publicproperties.h"

--- a/ext/test/pregmatch.c
+++ b/ext/test/pregmatch.c
@@ -1,0 +1,80 @@
+
+#ifdef HAVE_CONFIG_H
+#include "../ext_config.h"
+#endif
+
+#include <php.h>
+#include "../php_ext.h"
+#include "../ext.h"
+
+#include <Zend/zend_operators.h>
+#include <Zend/zend_exceptions.h>
+#include <Zend/zend_interfaces.h>
+
+#include "kernel/main.h"
+#include "kernel/memory.h"
+#include "kernel/string.h"
+
+
+ZEPHIR_INIT_CLASS(Test_Pregmatch) {
+
+	ZEPHIR_REGISTER_CLASS(Test, Pregmatch, test, pregmatch, test_pregmatch_method_entry, 0);
+
+
+	return SUCCESS;
+
+}
+
+PHP_METHOD(Test_Pregmatch, testWithoutReturnAndMatches) {
+
+	zval *pattern, *subject, *_0, *_1, *_2;
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_INIT_VAR(pattern);
+	ZVAL_STRING(pattern, "/def$/", 1);
+	ZEPHIR_INIT_VAR(subject);
+	ZVAL_STRING(subject, "abcdef", 1);
+	ZEPHIR_INIT_VAR(_0);
+	ZEPHIR_INIT_VAR(_1);
+	zephir_preg_match(_1, &(_1), pattern, subject, _0 TSRMLS_CC);
+	ZEPHIR_INIT_VAR(_2);
+	zephir_preg_match(return_value, &(return_value), pattern, subject, _2 TSRMLS_CC);
+	RETURN_MM();
+
+}
+
+PHP_METHOD(Test_Pregmatch, testWithoutReturns) {
+
+	zval *pattern, *subject, *matches, *_0;
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_INIT_VAR(pattern);
+	ZVAL_STRING(pattern, "/def$/", 1);
+	ZEPHIR_INIT_VAR(subject);
+	ZVAL_STRING(subject, "abcdef", 1);
+	ZEPHIR_INIT_VAR(matches);
+	ZEPHIR_INIT_VAR(_0);
+	zephir_preg_match(_0, &(_0), pattern, subject, matches TSRMLS_CC);
+	RETURN_CCTOR(matches);
+
+}
+
+PHP_METHOD(Test_Pregmatch, testWithoutMatches) {
+
+	zval *pattern, *subject, *matched, *_0;
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_INIT_VAR(pattern);
+	ZVAL_STRING(pattern, "/def$/", 1);
+	ZEPHIR_INIT_VAR(subject);
+	ZVAL_STRING(subject, "abcdef", 1);
+	ZEPHIR_INIT_VAR(_0);
+	ZEPHIR_INIT_VAR(matched);
+	zephir_preg_match(matched, &(matched), pattern, subject, _0 TSRMLS_CC);
+	RETURN_CCTOR(matched);
+
+}
+

--- a/ext/test/pregmatch.h
+++ b/ext/test/pregmatch.h
@@ -1,0 +1,15 @@
+
+extern zend_class_entry *test_pregmatch_ce;
+
+ZEPHIR_INIT_CLASS(Test_Pregmatch);
+
+PHP_METHOD(Test_Pregmatch, testWithoutReturnAndMatches);
+PHP_METHOD(Test_Pregmatch, testWithoutReturns);
+PHP_METHOD(Test_Pregmatch, testWithoutMatches);
+
+ZEPHIR_INIT_FUNCS(test_pregmatch_method_entry) {
+	PHP_ME(Test_Pregmatch, testWithoutReturnAndMatches, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Pregmatch, testWithoutReturns, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Pregmatch, testWithoutMatches, NULL, ZEND_ACC_PUBLIC)
+	PHP_FE_END
+};

--- a/ext/test/router.c
+++ b/ext/test/router.c
@@ -390,10 +390,10 @@ PHP_METHOD(Test_Router, doRemoveExtraSlashes) {
  */
 PHP_METHOD(Test_Router, handle) {
 
-	zend_function *_5 = NULL, *_8 = NULL, *_9 = NULL, *_10 = NULL, *_11 = NULL, *_12 = NULL, *_13 = NULL, *_14 = NULL, *_15 = NULL, *_16 = NULL;
-	HashTable *_3, *_18;
-	HashPosition _2, _17;
-	zval *uri = NULL, *realUri = NULL, *request = NULL, *currentHostName = NULL, *routeFound = NULL, *parts = NULL, *params, *matches, *notFoundPaths, *vnamespace, *module, *controller, *action, *paramsStr, *strParams, *paramsMerge = NULL, *route = NULL, *methods = NULL, *dependencyInjector = NULL, *hostname = NULL, *regexHostName = NULL, *matched = NULL, *pattern = NULL, *handledUri = NULL, *beforeMatch = NULL, *paths = NULL, *converters = NULL, *part = NULL, *position = NULL, *matchPosition, *_0, *_1, **_4, *_6, *_7 = NULL, **_19, _20 = zval_used_for_init, *_21, *_22, *_23, *_24;
+	zend_function *_5 = NULL, *_8 = NULL, *_9 = NULL, *_10 = NULL, *_11 = NULL, *_12 = NULL, *_14 = NULL, *_15 = NULL, *_16 = NULL, *_17 = NULL;
+	HashTable *_3, *_19;
+	HashPosition _2, _18;
+	zval *uri = NULL, *realUri = NULL, *request = NULL, *currentHostName = NULL, *routeFound = NULL, *parts = NULL, *params, *matches, *notFoundPaths, *vnamespace, *module, *controller, *action, *paramsStr, *strParams, *paramsMerge = NULL, *route = NULL, *methods = NULL, *dependencyInjector = NULL, *hostname = NULL, *regexHostName = NULL, *matched = NULL, *pattern = NULL, *handledUri = NULL, *beforeMatch = NULL, *paths = NULL, *converters = NULL, *part = NULL, *position = NULL, *matchPosition, *_0, *_1, **_4, *_6, *_7 = NULL, *_13 = NULL, **_20, _21 = zval_used_for_init, *_22, *_23, *_24, *_25;
 
 	ZEPHIR_MM_GROW();
 	zephir_fetch_params(1, 0, 1, &uri);
@@ -488,7 +488,8 @@ PHP_METHOD(Test_Router, handle) {
 				} else {
 					ZEPHIR_CPY_WRT(regexHostName, hostname);
 				}
-				zephir_call_func_p2(matched, "preg_match", regexHostName, currentHostName);
+				ZEPHIR_INIT_NVAR(_13);
+				zephir_preg_match(matched, &(matched), regexHostName, currentHostName, _13 TSRMLS_CC);
 			} else {
 				ZVAL_BOOL(matched, ZEPHIR_IS_EQUAL(currentHostName, hostname));
 			}
@@ -497,17 +498,16 @@ PHP_METHOD(Test_Router, handle) {
 			}
 		}
 		ZEPHIR_INIT_NVAR(pattern);
-		zephir_call_method_cache(pattern, route, "getcompiledpattern", &_13);
+		zephir_call_method_cache(pattern, route, "getcompiledpattern", &_14);
 		ZEPHIR_INIT_NVAR(routeFound);
 		if (zephir_memnstr_str(pattern, SL("^"), "test/router.zep", 400)) {
-			Z_SET_ISREF_P(matches);
-			zephir_call_func_p3(routeFound, "preg_match", pattern, handledUri, matches);
+			zephir_preg_match(routeFound, &(routeFound), pattern, handledUri, matches TSRMLS_CC);
 		} else {
 			ZVAL_BOOL(routeFound, ZEPHIR_IS_EQUAL(pattern, handledUri));
 		}
 		if (zephir_is_true(routeFound)) {
 			ZEPHIR_INIT_NVAR(beforeMatch);
-			zephir_call_method_cache(beforeMatch, route, "getbeforematch", &_14);
+			zephir_call_method_cache(beforeMatch, route, "getbeforematch", &_15);
 			if ((Z_TYPE_P(beforeMatch) != IS_NULL)) {
 				if (zephir_is_callable(beforeMatch TSRMLS_CC)) {
 					ZEPHIR_THROW_EXCEPTION_STR(test_router_exception_ce, "Before-Match callback is not callable in matched route");
@@ -517,18 +517,18 @@ PHP_METHOD(Test_Router, handle) {
 		}
 		if (zephir_is_true(routeFound)) {
 			ZEPHIR_INIT_NVAR(paths);
-			zephir_call_method_cache(paths, route, "getpaths", &_15);
+			zephir_call_method_cache(paths, route, "getpaths", &_16);
 			ZEPHIR_CPY_WRT(parts, paths);
 			if ((Z_TYPE_P(matches) == IS_ARRAY)) {
 				ZEPHIR_INIT_NVAR(converters);
-				zephir_call_method_cache(converters, route, "getconverters", &_16);
-				zephir_is_iterable(paths, &_18, &_17, 0, 0);
+				zephir_call_method_cache(converters, route, "getconverters", &_17);
+				zephir_is_iterable(paths, &_19, &_18, 0, 0);
 				for (
-					; zend_hash_get_current_data_ex(_18, (void**) &_19, &_17) == SUCCESS
-					; zend_hash_move_forward_ex(_18, &_17)
+					; zend_hash_get_current_data_ex(_19, (void**) &_20, &_18) == SUCCESS
+					; zend_hash_move_forward_ex(_19, &_18)
 				) {
-					ZEPHIR_GET_HMKEY(part, _18, _17);
-					ZEPHIR_GET_HVALUE(position, _19);
+					ZEPHIR_GET_HMKEY(part, _19, _18);
+					ZEPHIR_GET_HVALUE(position, _20);
 					if (zephir_array_isset_fetch(&matchPosition, matches, position, 1 TSRMLS_CC)) {
 						if ((Z_TYPE_P(converters) == IS_ARRAY)) {
 							if (zephir_array_isset(converters, part)) {
@@ -600,15 +600,15 @@ PHP_METHOD(Test_Router, handle) {
 			zephir_update_property_this(this_ptr, SL("_action"), _6 TSRMLS_CC);
 		}
 		if (zephir_array_isset_string_fetch(&paramsStr, parts, SS("params"), 1 TSRMLS_CC)) {
-			ZEPHIR_SINIT_VAR(_20);
-			ZVAL_LONG(&_20, 1);
+			ZEPHIR_SINIT_VAR(_21);
+			ZVAL_LONG(&_21, 1);
 			ZEPHIR_INIT_VAR(strParams);
-			zephir_call_func_p2(strParams, "substr", paramsStr, &_20);
+			zephir_call_func_p2(strParams, "substr", paramsStr, &_21);
 			if (zephir_is_true(strParams)) {
-				ZEPHIR_SINIT_NVAR(_20);
-				ZVAL_STRING(&_20, "/", 0);
+				ZEPHIR_SINIT_NVAR(_21);
+				ZVAL_STRING(&_21, "/", 0);
 				ZEPHIR_INIT_BNVAR(params);
-				zephir_call_func_p2(params, "explode", &_20, strParams);
+				zephir_call_func_p2(params, "explode", &_21, strParams);
 			}
 			zephir_array_unset_string(&parts, SS("params"), PH_SEPARATE);
 		}
@@ -622,14 +622,14 @@ PHP_METHOD(Test_Router, handle) {
 	} else {
 		_6 = zephir_fetch_nproperty_this(this_ptr, SL("_defaultNamespace"), PH_NOISY_CC);
 		zephir_update_property_this(this_ptr, SL("_namespace"), _6 TSRMLS_CC);
-		_21 = zephir_fetch_nproperty_this(this_ptr, SL("_defaultModule"), PH_NOISY_CC);
-		zephir_update_property_this(this_ptr, SL("_module"), _21 TSRMLS_CC);
-		_22 = zephir_fetch_nproperty_this(this_ptr, SL("_defaultController"), PH_NOISY_CC);
-		zephir_update_property_this(this_ptr, SL("_controller"), _22 TSRMLS_CC);
-		_23 = zephir_fetch_nproperty_this(this_ptr, SL("_defaultAction"), PH_NOISY_CC);
-		zephir_update_property_this(this_ptr, SL("_action"), _23 TSRMLS_CC);
-		_24 = zephir_fetch_nproperty_this(this_ptr, SL("_defaultParams"), PH_NOISY_CC);
-		zephir_update_property_this(this_ptr, SL("_params"), _24 TSRMLS_CC);
+		_22 = zephir_fetch_nproperty_this(this_ptr, SL("_defaultModule"), PH_NOISY_CC);
+		zephir_update_property_this(this_ptr, SL("_module"), _22 TSRMLS_CC);
+		_23 = zephir_fetch_nproperty_this(this_ptr, SL("_defaultController"), PH_NOISY_CC);
+		zephir_update_property_this(this_ptr, SL("_controller"), _23 TSRMLS_CC);
+		_24 = zephir_fetch_nproperty_this(this_ptr, SL("_defaultAction"), PH_NOISY_CC);
+		zephir_update_property_this(this_ptr, SL("_action"), _24 TSRMLS_CC);
+		_25 = zephir_fetch_nproperty_this(this_ptr, SL("_defaultParams"), PH_NOISY_CC);
+		zephir_update_property_this(this_ptr, SL("_params"), _25 TSRMLS_CC);
 	}
 	ZEPHIR_MM_RESTORE();
 

--- a/templates/config.m4
+++ b/templates/config.m4
@@ -4,4 +4,26 @@ if test "$PHP_%PROJECT_UPPER%" = "yes"; then
 	AC_DEFINE(HAVE_%PROJECT_UPPER%, 1, [Whether you have %PROJECT_CAMELIZE%])
 	%PROJECT_LOWER%_sources="%PROJECT_LOWER%.c kernel/main.c kernel/memory.c kernel/exception.c kernel/hash.c kernel/debug.c kernel/backtrace.c kernel/object.c kernel/array.c kernel/string.c kernel/fcall.c kernel/require.c kernel/alternative/fcall.c kernel/file.c kernel/operators.c kernel/concat.c %FILES_COMPILED% %EXTRA_FILES_COMPILED%"
 	PHP_NEW_EXTENSION(%PROJECT_LOWER%, $%PROJECT_LOWER%_sources, $ext_shared)
+
+	old_CPPFLAGS=$CPPFLAGS
+	CPPFLAGS="$CPPFLAGS $INCLUDES"
+
+	AC_CHECK_DECL(
+		[HAVE_BUNDLED_PCRE],
+		[
+			AC_CHECK_HEADERS(
+				[ext/pcre/php_pcre.h],
+				[
+					PHP_ADD_EXTENSION_DEP([%PROJECT_LOWER%], [pcre])
+					AC_DEFINE([ZEPHIR_USE_PHP_PCRE], [1], [Whether PHP pcre extension is present at compile time])
+				],
+				,
+				[[#include "main/php.h"]]
+			)
+		],
+		,
+		[[#include "php_config.h"]]
+	)
+
+	CPPFLAGS=$old_CPPFLAGS
 fi

--- a/test/pregmatch.zep
+++ b/test/pregmatch.zep
@@ -1,0 +1,44 @@
+namespace Test;
+
+class Pregmatch
+{
+	public function testWithoutReturnAndMatches()
+	{
+            var pattern, subject;
+
+            let pattern = "/def$/";
+            let subject = "abcdef";
+
+            // without return auto created temp variable
+            preg_match(pattern, subject);
+
+            // compiler optimized , using return_value variable
+            return preg_match(pattern, subject);
+
+	}
+
+	public function testWithoutReturns()
+	{
+            var pattern, subject, matches;
+
+            let pattern = "/def$/";
+            let subject = "abcdef";
+
+            preg_match(pattern, subject, matches);
+
+            return matches;
+	}
+
+	public function testWithoutMatches()
+	{
+            var pattern, subject, matched;
+
+            let pattern = "/def$/";
+            let subject = "abcdef";
+
+            let matched = preg_match(pattern, subject);
+
+            return matched;
+	}
+
+}

--- a/unit-tests/pregmatch.php
+++ b/unit-tests/pregmatch.php
@@ -1,0 +1,11 @@
+<?php
+
+$t = new Test\Pregmatch();
+
+assert($t->testWithoutReturnAndMatches());
+
+assert($t->testWithoutReturns() == array('def'));
+
+assert($t->testWithoutMatches());
+
+

--- a/unit-tests/run_tests
+++ b/unit-tests/run_tests
@@ -18,3 +18,4 @@ valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv whic
 valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv which php) ./unit-tests/fannkuch.php
 valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv which php) ./unit-tests/scallexternal.php
 valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv which php) ./unit-tests/cblock.php
+valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv which php) ./unit-tests/pregmatch.php


### PR DESCRIPTION
Hi, 

I have Added PregMatchOptimizer. It use PHP internal PCRE implements not userland  `preg_match` function call.

PregMatchOptimizer is smart enough, and much compatible with php userland's `preg_match`

It support optional return , and optional parameters ...

ex:

```
 let matched = preg_match(pattern, subject) ;  or
 let matched = preg_match(pattern, subject, matches); or
 preg_match(pattern, subject, matches); // without return value
 preg_match(pattern, subject); // it's ok , but why you do that ;)
```

Signed-off-by: Rack Lin racklin@gmail.com
