### PR TITLE
Added JsonEncodeOptimizer and JsonDecodeOptimizer. Use PHP internal php_...

### DIFF
--- a/Library/Optimizers/FunctionCall/JsonDecodeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/JsonDecodeOptimizer.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2014 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+ | Authors: Rack Lin <racklin@gmail.com>                                    |
+ +--------------------------------------------------------------------------+
+*/
+
+/**
+ * JsonDecodeOptimizer
+ *
+ * Optimizes calls to 'json_decode' using internal function
+ */
+class JsonDecodeOptimizer
+	extends OptimizerAbstract
+{
+	/**
+	 * @param array $expression
+	 * @param Call $call
+	 * @param CompilationContext $context
+	 * @return bool|CompiledExpression|mixed
+	 */
+	public function optimize(array $expression, Call $call, CompilationContext $context)
+	{
+		if (!isset($expression['parameters'])) {
+			return false;
+		}
+
+		/**
+		 * Process the expected symbol to be returned
+		 */
+		$call->processExpectedReturn($context);
+
+		$symbolVariable = $call->getSymbolVariable();
+                if ($symbolVariable) {
+                    if ($symbolVariable->getType() != 'variable') {
+                            throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
+                    }
+                    if ($call->mustInitSymbolVariable()) {
+                            $symbolVariable->initVariant($context);
+                    }
+                } else {
+                    $symbolVariable = $context->symbolTable->addTemp('variable', $context);
+                    $symbolVariable->initVariant($context);
+                }
+
+		$context->headersManager->add('kernel/string');
+
+		$resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+
+                /**
+                 * Process encode options
+                 */
+                if (count($resolvedParams) >= 2) {
+                    $options = 'Z_LVAL_P('.$resolvedParams[1].') ';
+                }else {
+                    $options = '0 ';
+                }
+
+		$context->codePrinter->output('zephir_json_decode(' . $symbolVariable->getName() . ', &(' . $symbolVariable->getName() . '), ' . $resolvedParams[0] . ', '. $options .' TSRMLS_CC);');
+		return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
+	}
+}

--- a/Library/Optimizers/FunctionCall/JsonEncodeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/JsonEncodeOptimizer.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2014 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+ | Authors: Rack Lin <racklin@gmail.com>                                    |
+ +--------------------------------------------------------------------------+
+*/
+
+/**
+ * JsonEncodeOptimizer
+ *
+ * Optimizes calls to 'json_encode' using internal function
+ */
+class JsonEncodeOptimizer
+	extends OptimizerAbstract
+{
+	/**
+	 * @param array $expression
+	 * @param Call $call
+	 * @param CompilationContext $context
+	 * @return bool|CompiledExpression|mixed
+	 */
+	public function optimize(array $expression, Call $call, CompilationContext $context)
+	{
+		if (!isset($expression['parameters'])) {
+			return false;
+		}
+
+		/**
+		 * Process the expected symbol to be returned
+		 */
+		$call->processExpectedReturn($context);
+
+		$symbolVariable = $call->getSymbolVariable();
+                if ($symbolVariable) {
+                    if ($symbolVariable->getType() != 'variable') {
+                            throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
+                    }
+                    if ($call->mustInitSymbolVariable()) {
+                            $symbolVariable->initVariant($context);
+                    }
+                } else {
+                    $symbolVariable = $context->symbolTable->addTemp('variable', $context);
+                    $symbolVariable->initVariant($context);
+                }
+
+		$context->headersManager->add('kernel/string');
+
+		$resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+
+                /**
+                 * Process encode options
+                 */
+                if (count($resolvedParams) >= 2) {
+                    $options = 'Z_LVAL_P('.$resolvedParams[1].') ';
+                }else {
+                    $options = '0 ';
+                }
+
+		$context->codePrinter->output('zephir_json_encode(' . $symbolVariable->getName() . ', &(' . $symbolVariable->getName() . '), ' . $resolvedParams[0] . ', '. $options .' TSRMLS_CC);');
+		return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
+	}
+}

--- a/ext/config.m4
+++ b/ext/config.m4
@@ -2,7 +2,7 @@ PHP_ARG_ENABLE(test, whether to enable test, [ --enable-test   Enable Test])
 
 if test "$PHP_TEST" = "yes"; then
 	AC_DEFINE(HAVE_TEST, 1, [Whether you have Test])
-	test_sources="test.c kernel/main.c kernel/memory.c kernel/exception.c kernel/hash.c kernel/debug.c kernel/backtrace.c kernel/object.c kernel/array.c kernel/string.c kernel/fcall.c kernel/require.c kernel/alternative/fcall.c kernel/file.c kernel/operators.c kernel/concat.c kernel/variables.c test/arithmetic.c test/assign.c test/cast.c test/cblock.c test/constants.c test/constantsinterface.c test/constantsparent.c test/declare.c test/echoes.c test/emptytest.c test/exception.c test/exceptions.c test/fannkuch.c test/fcall.c test/fibonnaci.c test/flow.c test/fortytwo.c test/mcall.c test/mcallchained.c test/nativearray.c test/oo.c test/oo/ooconstruct.c test/oo/ooconstructparams.c test/oo/oodynamica.c test/oo/oodynamicb.c test/oo/oonoconstruct.c test/oo/ooparams.c test/oo/propertyaccess.c test/pregmatch.c test/properties/privateproperties.c test/properties/protectedproperties.c test/properties/publicproperties.c test/regexdna.c test/returns.c test/router.c test/router/exception.c test/router/route.c test/scall.c test/scallexternal.c test/scallparent.c test/spectralnorm.c test/testinterface.c test/vars.c "
+	test_sources="test.c kernel/main.c kernel/memory.c kernel/exception.c kernel/hash.c kernel/debug.c kernel/backtrace.c kernel/object.c kernel/array.c kernel/string.c kernel/fcall.c kernel/require.c kernel/alternative/fcall.c kernel/file.c kernel/operators.c kernel/concat.c kernel/variables.c test/arithmetic.c test/assign.c test/cast.c test/cblock.c test/constants.c test/constantsinterface.c test/constantsparent.c test/declare.c test/echoes.c test/emptytest.c test/exception.c test/exceptions.c test/fannkuch.c test/fcall.c test/fibonnaci.c test/flow.c test/fortytwo.c test/json.c test/mcall.c test/mcallchained.c test/nativearray.c test/oo.c test/oo/ooconstruct.c test/oo/ooconstructparams.c test/oo/oodynamica.c test/oo/oodynamicb.c test/oo/oonoconstruct.c test/oo/ooparams.c test/oo/propertyaccess.c test/pregmatch.c test/properties/privateproperties.c test/properties/protectedproperties.c test/properties/publicproperties.c test/regexdna.c test/returns.c test/router.c test/router/exception.c test/router/route.c test/scall.c test/scallexternal.c test/scallparent.c test/spectralnorm.c test/testinterface.c test/vars.c "
 	PHP_NEW_EXTENSION(test, $test_sources, $ext_shared)
 
 	old_CPPFLAGS=$CPPFLAGS
@@ -16,6 +16,23 @@ if test "$PHP_TEST" = "yes"; then
 				[
 					PHP_ADD_EXTENSION_DEP([test], [pcre])
 					AC_DEFINE([ZEPHIR_USE_PHP_PCRE], [1], [Whether PHP pcre extension is present at compile time])
+				],
+				,
+				[[#include "main/php.h"]]
+			)
+		],
+		,
+		[[#include "php_config.h"]]
+	)
+
+	AC_CHECK_DECL(
+		[HAVE_JSON],
+		[
+			AC_CHECK_HEADERS(
+				[ext/json/php_json.h],
+				[
+					PHP_ADD_EXTENSION_DEP([test], [json])
+					AC_DEFINE([ZEPHIR_USE_PHP_JSON], [1], [Whether PHP json extension is present at compile time])
 				],
 				,
 				[[#include "main/php.h"]]

--- a/ext/test.c
+++ b/ext/test.c
@@ -36,6 +36,7 @@ zend_class_entry *test_fcall_ce;
 zend_class_entry *test_fibonnaci_ce;
 zend_class_entry *test_flow_ce;
 zend_class_entry *test_fortytwo_ce;
+zend_class_entry *test_json_ce;
 zend_class_entry *test_mcall_ce;
 zend_class_entry *test_mcallchained_ce;
 zend_class_entry *test_nativearray_ce;
@@ -84,6 +85,7 @@ PHP_MINIT_FUNCTION(test){
 	ZEPHIR_INIT(Test_Fibonnaci);
 	ZEPHIR_INIT(Test_Flow);
 	ZEPHIR_INIT(Test_FortyTwo);
+	ZEPHIR_INIT(Test_Json);
 	ZEPHIR_INIT(Test_Mcall);
 	ZEPHIR_INIT(Test_McallChained);
 	ZEPHIR_INIT(Test_NativeArray);

--- a/ext/test.h
+++ b/ext/test.h
@@ -19,6 +19,7 @@
 #include "test/fibonnaci.h"
 #include "test/flow.h"
 #include "test/fortytwo.h"
+#include "test/json.h"
 #include "test/mcall.h"
 #include "test/mcallchained.h"
 #include "test/nativearray.h"

--- a/ext/test/emptytest.c
+++ b/ext/test/emptytest.c
@@ -51,7 +51,7 @@ PHP_METHOD(Test_EmptyTest, testDynamicVarArrayNotEmpty) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 5);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);

--- a/ext/test/fannkuch.c
+++ b/ext/test/fannkuch.c
@@ -145,7 +145,7 @@ PHP_METHOD(Test_Fannkuch, process) {
 		}
 		while (1) {
 			if ((r == n)) {
-				array_init(return_value);
+				array_init_size(return_value, 4);
 				ZEPHIR_INIT_NVAR(_13);
 				ZVAL_LONG(_13, checksum);
 				zephir_array_fast_append(return_value, _13);

--- a/ext/test/fibonnaci.c
+++ b/ext/test/fibonnaci.c
@@ -76,7 +76,7 @@ PHP_METHOD(Test_Fibonnaci, fibArray) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(fib);
-	array_init(fib);
+	array_init_size(fib, 3);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 0);
 	zephir_array_fast_append(fib, _0);
@@ -110,7 +110,7 @@ PHP_METHOD(Test_Fibonnaci, fibArray2) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(fib);
-	array_init(fib);
+	array_init_size(fib, 3);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 0);
 	zephir_array_fast_append(fib, _0);

--- a/ext/test/flow.c
+++ b/ext/test/flow.c
@@ -591,7 +591,7 @@ PHP_METHOD(Test_Flow, testFor1) {
 
 	c = 0;
 	ZEPHIR_INIT_VAR(b);
-	array_init(b);
+	array_init_size(b, 5);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(b, _0);
@@ -627,7 +627,7 @@ PHP_METHOD(Test_Flow, testFor2) {
 
 	c = (double) (0);
 	ZEPHIR_INIT_VAR(b);
-	array_init(b);
+	array_init_size(b, 5);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(b, _0);
@@ -664,7 +664,7 @@ PHP_METHOD(Test_Flow, testFor3) {
 	ZEPHIR_INIT_VAR(c);
 	array_init(c);
 	ZEPHIR_INIT_VAR(b);
-	array_init(b);
+	array_init_size(b, 5);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(b, _0);

--- a/ext/test/fortytwo.c
+++ b/ext/test/fortytwo.c
@@ -44,9 +44,9 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(box);
-	array_init(box);
+	array_init_size(box, 16);
 	ZEPHIR_INIT_VAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_LONG(_1, 10);
 	zephir_array_fast_append(_0, _1);
@@ -58,7 +58,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 8);
 	zephir_array_fast_append(_0, _1);
@@ -70,7 +70,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 19);
 	zephir_array_fast_append(_0, _1);
@@ -82,7 +82,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 6);
 	zephir_array_fast_append(_0, _1);
@@ -94,7 +94,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 20);
 	zephir_array_fast_append(_0, _1);
@@ -106,7 +106,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 9);
 	zephir_array_fast_append(_0, _1);
@@ -118,7 +118,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 22);
 	zephir_array_fast_append(_0, _1);
@@ -130,7 +130,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 18);
 	zephir_array_fast_append(_0, _1);
@@ -142,7 +142,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 5);
 	zephir_array_fast_append(_0, _1);
@@ -154,7 +154,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 16);
 	zephir_array_fast_append(_0, _1);
@@ -166,7 +166,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 23);
 	zephir_array_fast_append(_0, _1);
@@ -178,7 +178,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 12);
 	zephir_array_fast_append(_0, _1);
@@ -190,7 +190,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 24);
 	zephir_array_fast_append(_0, _1);
@@ -202,7 +202,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 11);
 	zephir_array_fast_append(_0, _1);
@@ -214,7 +214,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init(_0);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 11);
 	zephir_array_fast_append(_0, _1);

--- a/ext/test/json.c
+++ b/ext/test/json.c
@@ -1,0 +1,132 @@
+
+#ifdef HAVE_CONFIG_H
+#include "../ext_config.h"
+#endif
+
+#include <php.h>
+#include "../php_ext.h"
+#include "../ext.h"
+
+#include <Zend/zend_operators.h>
+#include <Zend/zend_exceptions.h>
+#include <Zend/zend_interfaces.h>
+
+#include "kernel/main.h"
+#include "kernel/memory.h"
+#include "kernel/string.h"
+#include "kernel/array.h"
+
+
+ZEPHIR_INIT_CLASS(Test_Json) {
+
+	ZEPHIR_REGISTER_CLASS(Test, Json, test, json, test_json_method_entry, 0);
+
+
+	return SUCCESS;
+
+}
+
+PHP_METHOD(Test_Json, testEncodeObject) {
+
+	zval *obj;
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_INIT_VAR(obj);
+	array_init_size(obj, 4);
+	add_assoc_stringl_ex(obj, SS("a"), SL("hello"), 1);
+	add_assoc_stringl_ex(obj, SS("b"), SL("world"), 1);
+	add_assoc_long_ex(obj, SS("c"), 128);
+	zephir_json_encode(return_value, &(return_value), obj, 0  TSRMLS_CC);
+	RETURN_MM();
+
+}
+
+PHP_METHOD(Test_Json, testEncodeArray) {
+
+	zval *arr, *_0;
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_INIT_VAR(arr);
+	array_init_size(arr, 4);
+	ZEPHIR_INIT_VAR(_0);
+	ZVAL_LONG(_0, 1);
+	zephir_array_fast_append(arr, _0);
+	ZEPHIR_INIT_BNVAR(_0);
+	ZVAL_LONG(_0, 2);
+	zephir_array_fast_append(arr, _0);
+	ZEPHIR_INIT_BNVAR(_0);
+	ZVAL_LONG(_0, 3);
+	zephir_array_fast_append(arr, _0);
+	zephir_json_encode(return_value, &(return_value), arr, 0  TSRMLS_CC);
+	RETURN_MM();
+
+}
+
+PHP_METHOD(Test_Json, testEncodeOptions) {
+
+	zval *arr, *_0, _1;
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_INIT_VAR(arr);
+	array_init_size(arr, 5);
+	ZEPHIR_INIT_VAR(_0);
+	ZVAL_STRING(_0, "<foo>", 1);
+	zephir_array_fast_append(arr, _0);
+	ZEPHIR_INIT_BNVAR(_0);
+	ZVAL_STRING(_0, "'bar'", 1);
+	zephir_array_fast_append(arr, _0);
+	ZEPHIR_INIT_BNVAR(_0);
+	ZVAL_STRING(_0, "&blong&", 1);
+	zephir_array_fast_append(arr, _0);
+	ZEPHIR_INIT_BNVAR(_0);
+	ZVAL_STRING(_0, "\xc3\xa9", 1);
+	zephir_array_fast_append(arr, _0);
+	ZEPHIR_SINIT_VAR(_1);
+	ZVAL_LONG(&_1, 1);
+	zephir_json_encode(return_value, &(return_value), arr, Z_LVAL_P(&_1)  TSRMLS_CC);
+	RETURN_MM();
+
+}
+
+PHP_METHOD(Test_Json, testDecodeObject) {
+
+	zval *obj;
+
+	ZEPHIR_MM_GROW();
+	ZEPHIR_INIT_VAR(obj);
+	ZVAL_STRING(obj, "{\"a\":\"hello\",\"b\":\"world\",\"c\":128}", 1);
+
+	zephir_json_decode(return_value, &(return_value), obj, 0  TSRMLS_CC);
+	RETURN_MM();
+
+}
+
+PHP_METHOD(Test_Json, testDecodeObject2) {
+
+	zval *obj;
+
+	ZEPHIR_MM_GROW();
+	ZEPHIR_INIT_VAR(obj);
+	ZVAL_STRING(obj, "{\"a\":\"hello\",\"b\":\"world\",\"c\":128}", 1);
+
+	zephir_json_decode(return_value, &(return_value), obj, Z_LVAL_P(ZEPHIR_GLOBAL(global_true))  TSRMLS_CC);
+	RETURN_MM();
+
+}
+
+PHP_METHOD(Test_Json, testDecodeArray) {
+
+	zval *arr;
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_INIT_VAR(arr);
+	ZVAL_STRING(arr, "[1,2,3]", 1);
+	zephir_json_decode(return_value, &(return_value), arr, 0  TSRMLS_CC);
+	RETURN_MM();
+
+}
+

--- a/ext/test/json.h
+++ b/ext/test/json.h
@@ -1,0 +1,21 @@
+
+extern zend_class_entry *test_json_ce;
+
+ZEPHIR_INIT_CLASS(Test_Json);
+
+PHP_METHOD(Test_Json, testEncodeObject);
+PHP_METHOD(Test_Json, testEncodeArray);
+PHP_METHOD(Test_Json, testEncodeOptions);
+PHP_METHOD(Test_Json, testDecodeObject);
+PHP_METHOD(Test_Json, testDecodeObject2);
+PHP_METHOD(Test_Json, testDecodeArray);
+
+ZEPHIR_INIT_FUNCS(test_json_method_entry) {
+	PHP_ME(Test_Json, testEncodeObject, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Json, testEncodeArray, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Json, testEncodeOptions, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Json, testDecodeObject, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Json, testDecodeObject2, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Json, testDecodeArray, NULL, ZEND_ACC_PUBLIC)
+	PHP_FE_END
+};

--- a/ext/test/nativearray.c
+++ b/ext/test/nativearray.c
@@ -48,7 +48,7 @@ PHP_METHOD(Test_NativeArray, testArray2) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -69,7 +69,7 @@ PHP_METHOD(Test_NativeArray, testArray3) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_DOUBLE(_0, 1.1);
 	zephir_array_fast_append(a, _0);
@@ -90,7 +90,7 @@ PHP_METHOD(Test_NativeArray, testArray4) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_false));
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_true));
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_false));
@@ -105,7 +105,7 @@ PHP_METHOD(Test_NativeArray, testArray5) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_null));
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_null));
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_null));
@@ -120,7 +120,7 @@ PHP_METHOD(Test_NativeArray, testArray6) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "x", 1);
 	zephir_array_fast_append(a, _0);
@@ -145,7 +145,7 @@ PHP_METHOD(Test_NativeArray, testArray7) {
 	b = 2;
 	c = 3;
 	ZEPHIR_INIT_VAR(d);
-	array_init(d);
+	array_init_size(d, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, a);
 	zephir_array_fast_append(d, _0);
@@ -170,7 +170,7 @@ PHP_METHOD(Test_NativeArray, testArray8) {
 	b = (double) (2);
 	c = (double) (3);
 	ZEPHIR_INIT_VAR(d);
-	array_init(d);
+	array_init_size(d, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_DOUBLE(_0, a);
 	zephir_array_fast_append(d, _0);
@@ -195,7 +195,7 @@ PHP_METHOD(Test_NativeArray, testArray9) {
 	b = 0;
 	c = 1;
 	ZEPHIR_INIT_VAR(d);
-	array_init(d);
+	array_init_size(d, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_BOOL(_0, a);
 	zephir_array_fast_append(d, _0);
@@ -223,7 +223,7 @@ PHP_METHOD(Test_NativeArray, testArray10) {
 	ZEPHIR_INIT_VAR(c);
 	ZVAL_STRING(c, "hello3", 1);
 	ZEPHIR_INIT_VAR(d);
-	array_init(d);
+	array_init_size(d, 4);
 	zephir_array_fast_append(d, a);
 	zephir_array_fast_append(d, b);
 	zephir_array_fast_append(d, c);
@@ -238,7 +238,7 @@ PHP_METHOD(Test_NativeArray, testArray11) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -249,7 +249,7 @@ PHP_METHOD(Test_NativeArray, testArray11) {
 	ZVAL_LONG(_0, 3);
 	zephir_array_fast_append(a, _0);
 	ZEPHIR_INIT_VAR(b);
-	array_init(b);
+	array_init_size(b, 4);
 	ZEPHIR_INIT_BNVAR(_0);
 	ZVAL_LONG(_0, 4);
 	zephir_array_fast_append(b, _0);
@@ -260,7 +260,7 @@ PHP_METHOD(Test_NativeArray, testArray11) {
 	ZVAL_LONG(_0, 6);
 	zephir_array_fast_append(b, _0);
 	ZEPHIR_INIT_VAR(c);
-	array_init(c);
+	array_init_size(c, 3);
 	zephir_array_fast_append(c, a);
 	zephir_array_fast_append(c, b);
 	RETURN_CCTOR(c);
@@ -274,7 +274,7 @@ PHP_METHOD(Test_NativeArray, testArray12) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -285,10 +285,10 @@ PHP_METHOD(Test_NativeArray, testArray12) {
 	ZVAL_LONG(_0, 3);
 	zephir_array_fast_append(a, _0);
 	ZEPHIR_INIT_VAR(b);
-	array_init(b);
+	array_init_size(b, 2);
 	zephir_array_fast_append(b, a);
 	ZEPHIR_INIT_VAR(c);
-	array_init(c);
+	array_init_size(c, 2);
 	zephir_array_fast_append(c, b);
 	RETURN_CCTOR(c);
 
@@ -301,7 +301,7 @@ PHP_METHOD(Test_NativeArray, testArray13) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_index_stringl(a, 1, SL("hello1"), 1);
 	add_index_stringl(a, 2, SL("hello2"), 1);
 	add_index_stringl(a, 3, SL("hello3"), 1);
@@ -316,7 +316,7 @@ PHP_METHOD(Test_NativeArray, testArray14) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("hello1"), 1);
 	add_assoc_long_ex(a, SS("hello2"), 2);
 	add_assoc_long_ex(a, SS("hello3"), 3);
@@ -331,7 +331,7 @@ PHP_METHOD(Test_NativeArray, testArray15) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	zephir_array_update_string(&a, SL("hello1"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&a, SL("hello2"), &ZEPHIR_GLOBAL(global_false), PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&a, SL("hello3"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
@@ -346,7 +346,7 @@ PHP_METHOD(Test_NativeArray, testArray16) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_assoc_double_ex(a, SS("hello1"), 1.0);
 	add_assoc_double_ex(a, SS("hello2"), 2.0);
 	add_assoc_double_ex(a, SS("hello3"), 3.0);
@@ -361,7 +361,7 @@ PHP_METHOD(Test_NativeArray, testArray17) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	zephir_array_update_string(&a, SL("hello1"), &ZEPHIR_GLOBAL(global_null), PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&a, SL("hello2"), &ZEPHIR_GLOBAL(global_null), PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&a, SL("hello3"), &ZEPHIR_GLOBAL(global_null), PH_COPY | PH_SEPARATE);
@@ -376,7 +376,7 @@ PHP_METHOD(Test_NativeArray, testArray18) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_assoc_stringl_ex(a, SS("hello1"), SL("a"), 1);
 	add_assoc_stringl_ex(a, SS("hello2"), SL("b"), 1);
 	add_assoc_stringl_ex(a, SS("hello3"), SL("c"), 1);
@@ -391,7 +391,7 @@ PHP_METHOD(Test_NativeArray, testArray19) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_index_bool(a, 0, 1);
 	zephir_array_update_long(&a, 0, &ZEPHIR_GLOBAL(global_true), PH_COPY, "test/nativearray.zep", 147);
 	add_index_bool(a, 1, 0);
@@ -409,7 +409,7 @@ PHP_METHOD(Test_NativeArray, testArray20) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_index_double(a, 0, 1.0);
 	add_index_double(a, 1, 2.0);
 	add_index_double(a, 2, 3.0);
@@ -424,7 +424,7 @@ PHP_METHOD(Test_NativeArray, testArray21) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	zephir_array_update_long(&a, 0, &ZEPHIR_GLOBAL(global_null), PH_COPY, "test/nativearray.zep", 161);
 	zephir_array_update_long(&a, 1, &ZEPHIR_GLOBAL(global_null), PH_COPY, "test/nativearray.zep", 161);
 	zephir_array_update_long(&a, 2, &ZEPHIR_GLOBAL(global_null), PH_COPY, "test/nativearray.zep", 161);
@@ -439,7 +439,7 @@ PHP_METHOD(Test_NativeArray, testArray22) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_index_long(a, 0, 4);
 	add_index_long(a, 1, 5);
 	add_index_long(a, 2, 6);
@@ -456,7 +456,7 @@ PHP_METHOD(Test_NativeArray, testArray23) {
 
 	b = 0;
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, b);
 	zephir_array_update_long(&a, 0, &_0, PH_COPY, "test/nativearray.zep", 177);
@@ -479,7 +479,7 @@ PHP_METHOD(Test_NativeArray, testArray24) {
 
 	b = 0.0;
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_DOUBLE(_0, b);
 	zephir_array_update_long(&a, 0, &_0, PH_COPY, "test/nativearray.zep", 186);
@@ -502,7 +502,7 @@ PHP_METHOD(Test_NativeArray, testArray25) {
 
 	b = 0;
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_BOOL(_0, b);
 	zephir_array_update_long(&a, 0, &_0, PH_COPY, "test/nativearray.zep", 195);
@@ -525,7 +525,7 @@ PHP_METHOD(Test_NativeArray, testArray26) {
 	ZEPHIR_INIT_VAR(b);
 	ZVAL_NULL(b);
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	zephir_array_update_long(&a, 0, &b, PH_COPY, "test/nativearray.zep", 204);
 	zephir_array_update_long(&a, 1, &b, PH_COPY, "test/nativearray.zep", 204);
 	zephir_array_update_long(&a, 2, &b, PH_COPY, "test/nativearray.zep", 204);
@@ -543,7 +543,7 @@ PHP_METHOD(Test_NativeArray, testArray27) {
 	ZEPHIR_INIT_VAR(b);
 	ZVAL_STRING(b, "hello", 1);
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	zephir_array_update_long(&a, 0, &b, PH_COPY, "test/nativearray.zep", 213);
 	zephir_array_update_long(&a, 1, &b, PH_COPY, "test/nativearray.zep", 213);
 	zephir_array_update_long(&a, 2, &b, PH_COPY, "test/nativearray.zep", 213);
@@ -561,7 +561,7 @@ PHP_METHOD(Test_NativeArray, testArray28) {
 	ZEPHIR_INIT_VAR(b);
 	ZVAL_STRING(b, "hello", 1);
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	zephir_array_update_long(&a, 0, &b, PH_COPY, "test/nativearray.zep", 222);
 	zephir_array_update_long(&a, 1, &b, PH_COPY, "test/nativearray.zep", 222);
 	zephir_array_update_long(&a, 2, &b, PH_COPY, "test/nativearray.zep", 222);
@@ -578,7 +578,7 @@ PHP_METHOD(Test_NativeArray, testArray29) {
 
 	b = 1;
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 2);
 	add_index_stringl(a, b, SL("hello"), 1);
 	RETURN_CCTOR(a);
 
@@ -594,7 +594,7 @@ PHP_METHOD(Test_NativeArray, testArray30) {
 	ZEPHIR_INIT_VAR(b);
 	ZVAL_STRING(b, "hello", 1);
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 2);
 	add_assoc_stringl_ex(a, Z_STRVAL_P(b), Z_STRLEN_P(b) + 1, SL("hello"), 1);
 	RETURN_CCTOR(a);
 
@@ -607,7 +607,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess1) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -629,7 +629,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess2) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);
@@ -646,7 +646,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess3) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -670,7 +670,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess4) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);
@@ -688,7 +688,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess5) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);
@@ -706,7 +706,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess6) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);
@@ -725,9 +725,9 @@ PHP_METHOD(Test_NativeArray, testArrayMultipleAccess1) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 2);
 	ZEPHIR_INIT_VAR(_0);
-	array_init(_0);
+	array_init_size(_0, 3);
 	add_index_stringl(_0, 0, SL("a"), 1);
 	add_index_stringl(_0, 1, SL("b"), 1);
 	zephir_array_update_long(&a, 0, &_0, PH_COPY, "test/nativearray.zep", 312);
@@ -744,9 +744,9 @@ PHP_METHOD(Test_NativeArray, testArrayMultipleAccess2) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 2);
 	ZEPHIR_INIT_VAR(_0);
-	array_init(_0);
+	array_init_size(_0, 3);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_STRING(_1, "a", 1);
 	zephir_array_fast_append(_0, _1);
@@ -767,11 +767,11 @@ PHP_METHOD(Test_NativeArray, testArrayMultipleAccess3) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 2);
 	ZEPHIR_INIT_VAR(_0);
-	array_init(_0);
+	array_init_size(_0, 2);
 	ZEPHIR_INIT_VAR(_1);
-	array_init(_1);
+	array_init_size(_1, 3);
 	ZEPHIR_INIT_VAR(_2);
 	ZVAL_STRING(_2, "a", 1);
 	zephir_array_fast_append(_1, _2);
@@ -794,11 +794,11 @@ PHP_METHOD(Test_NativeArray, testArrayMultipleAccess4) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 2);
 	ZEPHIR_INIT_VAR(_0);
-	array_init(_0);
+	array_init_size(_0, 2);
 	ZEPHIR_INIT_VAR(_1);
-	array_init(_1);
+	array_init_size(_1, 3);
 	ZEPHIR_INIT_VAR(_2);
 	ZVAL_STRING(_2, "a", 1);
 	zephir_array_fast_append(_1, _2);
@@ -821,11 +821,11 @@ PHP_METHOD(Test_NativeArray, testArrayMultipleAccess5) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 2);
 	ZEPHIR_INIT_VAR(_0);
-	array_init(_0);
+	array_init_size(_0, 2);
 	ZEPHIR_INIT_VAR(_1);
-	array_init(_1);
+	array_init_size(_1, 3);
 	add_assoc_long_ex(_1, SS("c"), 0);
 	add_assoc_long_ex(_1, SS("d"), 1);
 	zephir_array_update_string(&_0, SL("b"), &_1, PH_COPY | PH_SEPARATE);
@@ -844,7 +844,7 @@ PHP_METHOD(Test_NativeArray, testArrayUpdate1) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -869,7 +869,7 @@ PHP_METHOD(Test_NativeArray, testArrayUpdate2) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -895,7 +895,7 @@ PHP_METHOD(Test_NativeArray, testArrayUpdate3) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -924,7 +924,7 @@ PHP_METHOD(Test_NativeArray, testArrayUpdate4) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init(a);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);

--- a/ext/test/oo/propertyaccess.c
+++ b/ext/test/oo/propertyaccess.c
@@ -40,7 +40,7 @@ PHP_METHOD(Test_Oo_PropertyAccess, __construct) {
 	ZEPHIR_INIT_VAR(test);
 	object_init(test);
 	ZEPHIR_INIT_VAR(_0);
-	array_init(_0);
+	array_init_size(_0, 6);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_LONG(_1, 1);
 	zephir_array_fast_append(_0, _1);
@@ -66,7 +66,7 @@ PHP_METHOD(Test_Oo_PropertyAccess, __construct) {
 	zephir_array_fetch_long(&_5, _4, 1, PH_NOISY | PH_READONLY TSRMLS_CC);
 	zephir_update_property_zval(test, SL("test3"), _5 TSRMLS_CC);
 	ZEPHIR_INIT_BNVAR(_1);
-	array_init(_1);
+	array_init_size(_1, 5);
 	ZEPHIR_OBS_VAR(_6);
 	zephir_read_property(&_6, test, SL("test"), PH_NOISY_CC);
 	ZEPHIR_OBS_VAR(_7);

--- a/ext/test/regexdna.c
+++ b/ext/test/regexdna.c
@@ -45,7 +45,7 @@ PHP_METHOD(Test_RegexDNA, process) {
 
 
 	ZEPHIR_INIT_VAR(variants);
-	array_init(variants);
+	array_init_size(variants, 10);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "agggtaaa|tttaccct", 1);
 	zephir_array_fast_append(variants, _0);

--- a/ext/test/router.c
+++ b/ext/test/router.c
@@ -104,7 +104,7 @@ PHP_METHOD(Test_Router, __construct) {
 		ZEPHIR_INIT_VAR(_0);
 		object_init_ex(_0, test_router_route_ce);
 		ZEPHIR_INIT_VAR(_1);
-		array_init(_1);
+		array_init_size(_1, 2);
 		add_assoc_long_ex(_1, SS("controller"), 1);
 		ZEPHIR_INIT_VAR(_2);
 		ZVAL_STRING(_2, "#^/([a-zA-Z0-9\\_\\-]+)[/]{0,1}$#", 1);
@@ -113,7 +113,7 @@ PHP_METHOD(Test_Router, __construct) {
 		ZEPHIR_INIT_NVAR(_2);
 		object_init_ex(_2, test_router_route_ce);
 		ZEPHIR_INIT_VAR(_3);
-		array_init(_3);
+		array_init_size(_3, 4);
 		add_assoc_long_ex(_3, SS("controller"), 1);
 		add_assoc_long_ex(_3, SS("action"), 2);
 		add_assoc_long_ex(_3, SS("params"), 3);

--- a/ext/test/router/route.c
+++ b/ext/test/router/route.c
@@ -82,7 +82,7 @@ PHP_METHOD(Test_Router_Route, __construct) {
  */
 PHP_METHOD(Test_Router_Route, compilePattern) {
 
-	zval *pattern = NULL, *idPattern, _0 = zval_used_for_init, *_1 = NULL, _2 = zval_used_for_init;
+	zval *pattern = NULL, *idPattern, *_0 = NULL, _1 = zval_used_for_init, _2 = zval_used_for_init;
 
 	ZEPHIR_MM_GROW();
 	zephir_fetch_params(1, 1, 0, &pattern);
@@ -94,50 +94,50 @@ PHP_METHOD(Test_Router_Route, compilePattern) {
 		ZEPHIR_INIT_VAR(idPattern);
 		ZVAL_STRING(idPattern, "/([a-zA-Z0-9\\_\\-]+)", 1);
 		if (zephir_memnstr_str(pattern, SL("/:module"), "test/router/route.zep", 63)) {
-			ZEPHIR_SINIT_VAR(_0);
-			ZVAL_STRING(&_0, "/:module", 0);
-			ZEPHIR_INIT_VAR(_1);
-			zephir_call_func_p3(_1, "str_replace", &_0, idPattern, pattern);
-			ZEPHIR_CPY_WRT(pattern, _1);
+			ZEPHIR_INIT_VAR(_0);
+			ZEPHIR_SINIT_VAR(_1);
+			ZVAL_STRING(&_1, "/:module", 0);
+			zephir_fast_str_replace(_0, &_1, idPattern, pattern);
+			ZEPHIR_CPY_WRT(pattern, _0);
 		}
 		if (zephir_memnstr_str(pattern, SL("/:controller"), "test/router/route.zep", 68)) {
-			ZEPHIR_SINIT_NVAR(_0);
-			ZVAL_STRING(&_0, "/:controller", 0);
-			ZEPHIR_INIT_NVAR(_1);
-			zephir_call_func_p3(_1, "str_replace", &_0, idPattern, pattern);
-			ZEPHIR_CPY_WRT(pattern, _1);
+			ZEPHIR_INIT_NVAR(_0);
+			ZEPHIR_SINIT_NVAR(_1);
+			ZVAL_STRING(&_1, "/:controller", 0);
+			zephir_fast_str_replace(_0, &_1, idPattern, pattern);
+			ZEPHIR_CPY_WRT(pattern, _0);
 		}
 		if (zephir_memnstr_str(pattern, SL("/:namespace"), "test/router/route.zep", 73)) {
-			ZEPHIR_SINIT_NVAR(_0);
-			ZVAL_STRING(&_0, "/:namespace", 0);
-			ZEPHIR_INIT_NVAR(_1);
-			zephir_call_func_p3(_1, "str_replace", &_0, idPattern, pattern);
-			ZEPHIR_CPY_WRT(pattern, _1);
+			ZEPHIR_INIT_NVAR(_0);
+			ZEPHIR_SINIT_NVAR(_1);
+			ZVAL_STRING(&_1, "/:namespace", 0);
+			zephir_fast_str_replace(_0, &_1, idPattern, pattern);
+			ZEPHIR_CPY_WRT(pattern, _0);
 		}
 		if (zephir_memnstr_str(pattern, SL("/:action"), "test/router/route.zep", 78)) {
-			ZEPHIR_SINIT_NVAR(_0);
-			ZVAL_STRING(&_0, "/:action", 0);
-			ZEPHIR_INIT_NVAR(_1);
-			zephir_call_func_p3(_1, "str_replace", &_0, idPattern, pattern);
-			ZEPHIR_CPY_WRT(pattern, _1);
+			ZEPHIR_INIT_NVAR(_0);
+			ZEPHIR_SINIT_NVAR(_1);
+			ZVAL_STRING(&_1, "/:action", 0);
+			zephir_fast_str_replace(_0, &_1, idPattern, pattern);
+			ZEPHIR_CPY_WRT(pattern, _0);
 		}
 		if (zephir_memnstr_str(pattern, SL("/:params"), "test/router/route.zep", 83)) {
-			ZEPHIR_SINIT_NVAR(_0);
-			ZVAL_STRING(&_0, "/:params", 0);
+			ZEPHIR_INIT_NVAR(_0);
+			ZEPHIR_SINIT_NVAR(_1);
+			ZVAL_STRING(&_1, "/:params", 0);
 			ZEPHIR_SINIT_VAR(_2);
 			ZVAL_STRING(&_2, "(/.*)*", 0);
-			ZEPHIR_INIT_NVAR(_1);
-			zephir_call_func_p3(_1, "str_replace", &_0, &_2, pattern);
-			ZEPHIR_CPY_WRT(pattern, _1);
+			zephir_fast_str_replace(_0, &_1, &_2, pattern);
+			ZEPHIR_CPY_WRT(pattern, _0);
 		}
 		if (zephir_memnstr_str(pattern, SL("/:int"), "test/router/route.zep", 88)) {
-			ZEPHIR_SINIT_NVAR(_0);
-			ZVAL_STRING(&_0, "/:int", 0);
+			ZEPHIR_INIT_NVAR(_0);
+			ZEPHIR_SINIT_NVAR(_1);
+			ZVAL_STRING(&_1, "/:int", 0);
 			ZEPHIR_SINIT_NVAR(_2);
 			ZVAL_STRING(&_2, "/([0-9]+)", 0);
-			ZEPHIR_INIT_NVAR(_1);
-			zephir_call_func_p3(_1, "str_replace", &_0, &_2, pattern);
-			ZEPHIR_CPY_WRT(pattern, _1);
+			zephir_fast_str_replace(_0, &_1, &_2, pattern);
+			ZEPHIR_CPY_WRT(pattern, _0);
 		}
 	}
 	if (zephir_memnstr_str(pattern, SL("("), "test/router/route.zep", 94)) {
@@ -329,7 +329,7 @@ PHP_METHOD(Test_Router_Route, extractNamedParams) {
 			zephir_concat_self_char(&route, ch TSRMLS_CC);
 		}
 	}
-	array_init(return_value);
+	array_init_size(return_value, 3);
 	zephir_array_fast_append(return_value, route);
 	zephir_array_fast_append(return_value, matches);
 	RETURN_MM();

--- a/ext/test/vars.c
+++ b/ext/test/vars.c
@@ -35,7 +35,7 @@ PHP_METHOD(Test_Vars, testVarDump) {
 	ZEPHIR_INIT_VAR(a);
 	ZVAL_STRING(a, "hello", 1);
 	ZEPHIR_INIT_VAR(ar);
-	array_init(ar);
+	array_init_size(ar, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(ar, _0);
@@ -58,7 +58,7 @@ PHP_METHOD(Test_Vars, testVarExport) {
 	ZEPHIR_INIT_VAR(a);
 	ZVAL_STRING(a, "hello", 1);
 	ZEPHIR_INIT_VAR(ar);
-	array_init(ar);
+	array_init_size(ar, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(ar, _0);

--- a/templates/config.m4
+++ b/templates/config.m4
@@ -25,5 +25,22 @@ if test "$PHP_%PROJECT_UPPER%" = "yes"; then
 		[[#include "php_config.h"]]
 	)
 
+	AC_CHECK_DECL(
+		[HAVE_JSON],
+		[
+			AC_CHECK_HEADERS(
+				[ext/json/php_json.h],
+				[
+					PHP_ADD_EXTENSION_DEP([%PROJECT_LOWER%], [json])
+					AC_DEFINE([ZEPHIR_USE_PHP_JSON], [1], [Whether PHP json extension is present at compile time])
+				],
+				,
+				[[#include "main/php.h"]]
+			)
+		],
+		,
+		[[#include "php_config.h"]]
+	)
+
 	CPPFLAGS=$old_CPPFLAGS
 fi

--- a/test/json.zep
+++ b/test/json.zep
@@ -1,0 +1,52 @@
+namespace Test;
+
+class Json
+{
+	public function testEncodeObject()
+	{
+            var obj;
+            let obj = ["a": "hello", "b": "world", "c": 128];
+
+            return json_encode(obj);
+	}
+
+	public function testEncodeArray()
+	{
+            var arr;
+            let arr = [1, 2, 3];
+
+            return json_encode(arr);
+	}
+
+	public function testEncodeOptions()
+	{
+            var arr;
+            let arr = ["<foo>","'bar'","&blong&", "\xc3\xa9"];
+
+            return json_encode(arr, JSON_HEX_TAG);
+	}
+
+        public function testDecodeObject() {
+
+            var obj = "{\"a\":\"hello\",\"b\":\"world\",\"c\":128}";
+
+            return json_decode(obj);
+
+        }
+
+        public function testDecodeObject2() {
+
+            var obj = "{\"a\":\"hello\",\"b\":\"world\",\"c\":128}";
+
+            return json_decode(obj, true);
+
+        }
+
+        public function testDecodeArray() {
+
+            var arr;
+            let arr = "[1,2,3]";
+
+            return json_decode(arr);
+        }
+}

--- a/unit-tests/json.php
+++ b/unit-tests/json.php
@@ -1,0 +1,18 @@
+<?php
+
+$t = new Test\Json();
+
+assert($t->testEncodeObject() == '{"a":"hello","b":"world","c":128}');
+
+assert($t->testEncodeArray() == '[1,2,3]');
+assert($t->testEncodeOptions() == '["\\u003Cfoo\\u003E","\'bar\'","&blong&","\\u00e9"]');
+
+$obj1 = $t->testDecodeObject();
+assert($obj1->a == 'hello');
+
+$arr1 = $t->testDecodeArray();
+assert($arr1[1] == 2);
+
+$obj2 = $t->testDecodeObject2();
+assert($obj2['a'] == 'hello');
+

--- a/unit-tests/run_tests
+++ b/unit-tests/run_tests
@@ -19,3 +19,4 @@ valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv whic
 valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv which php) ./unit-tests/scallexternal.php
 valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv which php) ./unit-tests/cblock.php
 valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv which php) ./unit-tests/pregmatch.php
+valgrind --read-var-info=yes --fullpath-after= --track-origins=yes $(phpenv which php) ./unit-tests/json.php


### PR DESCRIPTION
Hi,

I have Added JsonEncodeOptimizer and JsonDecodeOptimizer.
It use PHP internal php_json_encode/php_json_decode implements not userland function calls.

JsonEncodeOptimizer/JsonDecodeOptimizer compatible with php userland's `json_encode` and `json_decode`

It support optional return , and optional parameters ...

ex:

```
let str = json_encode(obj) ;  or
let str = json_encode(obj, JSON_HEX_QUOT) ; 

let obj = json_decode(str) ;  or
let obj = json_decode(str, true) ; // into  associative arrays. 
```

Signed-off-by: Rack Lin racklin@gmail.com
