### PR TITLE
Fixed VarDumpOptimizer support variable-length arguments, compatible for...

### DIFF
--- a/Library/Optimizers/FunctionCall/VarDumpOptimizer.php
+++ b/Library/Optimizers/FunctionCall/VarDumpOptimizer.php
@@ -42,9 +42,12 @@ class VarDumpOptimizer
 		$context->headersManager->add('kernel/variables');
 
 		$resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
-		$symbolVariable = $context->symbolTable->getVariable($resolvedParams[0]);
 
-		$context->codePrinter->output('zephir_var_dump(&(' . $resolvedParams[0] . ') TSRMLS_CC);');
+                foreach ($resolvedParams as $resolvedParam) {
+                    $symbolVariable = $context->symbolTable->getVariable($resolvedParam);
+                    $context->codePrinter->output('zephir_var_dump(&(' . $resolvedParam . ') TSRMLS_CC);');
+                }
+
 		return new CompiledExpression('null', 'null' , $expression);
 	}
 }

--- a/ext/test/vars.c
+++ b/ext/test/vars.c
@@ -137,3 +137,30 @@ PHP_METHOD(Test_Vars, test88IssueParam2InitString) {
 
 }
 
+PHP_METHOD(Test_Vars, testVarDump2param) {
+
+	zval *p1, *p2;
+
+	zephir_fetch_params(0, 2, 0, &p1, &p2);
+
+
+
+	zephir_var_dump(&(p1) TSRMLS_CC);
+	zephir_var_dump(&(p2) TSRMLS_CC);
+
+}
+
+PHP_METHOD(Test_Vars, testVarDump3param) {
+
+	zval *p1, *p2, *p3;
+
+	zephir_fetch_params(0, 3, 0, &p1, &p2, &p3);
+
+
+
+	zephir_var_dump(&(p1) TSRMLS_CC);
+	zephir_var_dump(&(p2) TSRMLS_CC);
+	zephir_var_dump(&(p3) TSRMLS_CC);
+
+}
+

--- a/ext/test/vars.h
+++ b/ext/test/vars.h
@@ -7,6 +7,8 @@ PHP_METHOD(Test_Vars, testVarDump);
 PHP_METHOD(Test_Vars, testVarExport);
 PHP_METHOD(Test_Vars, test88Issue);
 PHP_METHOD(Test_Vars, test88IssueParam2InitString);
+PHP_METHOD(Test_Vars, testVarDump2param);
+PHP_METHOD(Test_Vars, testVarDump3param);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_test_vars_test88issue, 0, 0, 1)
 	ZEND_ARG_INFO(0, param1)
@@ -18,10 +20,23 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_test_vars_test88issueparam2initstring, 0, 0, 1)
 	ZEND_ARG_INFO(0, param2)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_test_vars_testvardump2param, 0, 0, 2)
+	ZEND_ARG_INFO(0, p1)
+	ZEND_ARG_INFO(0, p2)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_test_vars_testvardump3param, 0, 0, 3)
+	ZEND_ARG_INFO(0, p1)
+	ZEND_ARG_INFO(0, p2)
+	ZEND_ARG_INFO(0, p3)
+ZEND_END_ARG_INFO()
+
 ZEPHIR_INIT_FUNCS(test_vars_method_entry) {
 	PHP_ME(Test_Vars, testVarDump, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Vars, testVarExport, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Vars, test88Issue, arginfo_test_vars_test88issue, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Vars, test88IssueParam2InitString, arginfo_test_vars_test88issueparam2initstring, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Vars, testVarDump2param, arginfo_test_vars_testvardump2param, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Vars, testVarDump3param, arginfo_test_vars_testvardump3param, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };

--- a/test/vars.zep
+++ b/test/vars.zep
@@ -44,4 +44,12 @@ class Vars
      {
           var_export(param2);
      }
+
+    public function testVarDump2param(var p1, var p2) {
+        var_dump(p1, p2);
+    }
+
+    public function testVarDump3param(var p1, var p2, var p3) {
+        var_dump(p1, p2, p3);
+    }
 }

--- a/unit-tests/vars.php
+++ b/unit-tests/vars.php
@@ -8,3 +8,7 @@ assert($t->testVarExport() == "'hello'");
 
 $t->test88Issue('foo', 'bar');
 $t->test88IssueParam2InitString('foo', 'bar');
+
+$t->testVarDump2param(3.1, true);
+$t->testVarDump3param(3.1, true, array(1,2,3));
+$t->testVarDump2param(3.1, true) ;


### PR DESCRIPTION
Fixed VarDumpOptimizer support variable-length arguments, compatible for userland PHP 'var_dump' function.

ex:

```
var_dump(1.3, true, array(1,2,3), 'foo', 'bar');
```

Signed-off-by: Rack Lin racklin@gmail.com
