### PR TITLE
Allow to create new class without write current namespace before class

### DIFF
--- a/ext/test/fannkuch.c
+++ b/ext/test/fannkuch.c
@@ -145,7 +145,7 @@ PHP_METHOD(Test_Fannkuch, process) {
 		}
 		while (1) {
 			if ((r == n)) {
-				array_init_size(return_value, 5);
+				array_init_size(return_value, 4);
 				ZEPHIR_INIT_NVAR(_13);
 				ZVAL_LONG(_13, checksum);
 				zephir_array_fast_append(return_value, _13);

--- a/ext/test/fcall.c
+++ b/ext/test/fcall.c
@@ -94,6 +94,8 @@ PHP_METHOD(Test_Fcall, testCall3) {
 			}
 			zephir_fwrite(NULL, handle2, buffer TSRMLS_CC);
 		}
+		zephir_fclose(handle TSRMLS_CC);
+		zephir_fclose(handle2 TSRMLS_CC);
 	}
 	ZEPHIR_MM_RESTORE();
 

--- a/ext/test/fortytwo.c
+++ b/ext/test/fortytwo.c
@@ -33,8 +33,7 @@ ZEPHIR_INIT_CLASS(Test_FortyTwo) {
 
 PHP_METHOD(Test_FortyTwo, proof) {
 
-	zend_function *_11 = NULL;
-	zend_class_entry *_10;
+	zend_function *_10 = NULL;
 	zend_bool _5;
 	HashTable *_3;
 	HashPosition _2;
@@ -44,9 +43,9 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(box);
-	array_init_size(box, 17);
+	array_init_size(box, 16);
 	ZEPHIR_INIT_VAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_LONG(_1, 10);
 	zephir_array_fast_append(_0, _1);
@@ -58,7 +57,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 8);
 	zephir_array_fast_append(_0, _1);
@@ -70,7 +69,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 19);
 	zephir_array_fast_append(_0, _1);
@@ -82,7 +81,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 6);
 	zephir_array_fast_append(_0, _1);
@@ -94,7 +93,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 20);
 	zephir_array_fast_append(_0, _1);
@@ -106,7 +105,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 9);
 	zephir_array_fast_append(_0, _1);
@@ -118,7 +117,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 22);
 	zephir_array_fast_append(_0, _1);
@@ -130,7 +129,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 18);
 	zephir_array_fast_append(_0, _1);
@@ -142,7 +141,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 5);
 	zephir_array_fast_append(_0, _1);
@@ -154,7 +153,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 16);
 	zephir_array_fast_append(_0, _1);
@@ -166,7 +165,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 23);
 	zephir_array_fast_append(_0, _1);
@@ -178,7 +177,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 12);
 	zephir_array_fast_append(_0, _1);
@@ -190,7 +189,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 24);
 	zephir_array_fast_append(_0, _1);
@@ -202,7 +201,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 11);
 	zephir_array_fast_append(_0, _1);
@@ -214,7 +213,7 @@ PHP_METHOD(Test_FortyTwo, proof) {
 	zephir_array_fast_append(_0, _1);
 	zephir_array_fast_append(box, _0);
 	ZEPHIR_INIT_BNVAR(_0);
-	array_init_size(_0, 5);
+	array_init_size(_0, 4);
 	ZEPHIR_INIT_BNVAR(_1);
 	ZVAL_LONG(_1, 11);
 	zephir_array_fast_append(_0, _1);
@@ -252,11 +251,10 @@ PHP_METHOD(Test_FortyTwo, proof) {
 		}
 		if ((j != 42)) {
 			ZEPHIR_INIT_LNVAR(_9);
-			_10 = zend_fetch_class(SL("Exception"), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
-			object_init_ex(_9, _10);
+			object_init_ex(_9, test_exception_ce);
 			ZEPHIR_INIT_NVAR(_0);
 			ZVAL_STRING(_0, "not true", 1);
-			zephir_call_method_p1_cache_noret(_9, "__construct", &_11, _0);
+			zephir_call_method_p1_cache_noret(_9, "__construct", &_10, _0);
 			zephir_throw_exception(_9 TSRMLS_CC);
 			ZEPHIR_MM_RESTORE();
 			return;

--- a/ext/test/json.c
+++ b/ext/test/json.c
@@ -34,7 +34,7 @@ PHP_METHOD(Test_Json, testEncodeObject) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(obj);
-	array_init_size(obj, 5);
+	array_init_size(obj, 4);
 	add_assoc_stringl_ex(obj, SS("a"), SL("hello"), 1);
 	add_assoc_stringl_ex(obj, SS("b"), SL("world"), 1);
 	add_assoc_long_ex(obj, SS("c"), 128);
@@ -50,7 +50,7 @@ PHP_METHOD(Test_Json, testEncodeArray) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(arr);
-	array_init_size(arr, 5);
+	array_init_size(arr, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(arr, _0);

--- a/ext/test/nativearray.c
+++ b/ext/test/nativearray.c
@@ -49,7 +49,7 @@ PHP_METHOD(Test_NativeArray, testArray2) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -70,7 +70,7 @@ PHP_METHOD(Test_NativeArray, testArray3) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_DOUBLE(_0, 1.1);
 	zephir_array_fast_append(a, _0);
@@ -91,7 +91,7 @@ PHP_METHOD(Test_NativeArray, testArray4) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_false));
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_true));
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_false));
@@ -106,7 +106,7 @@ PHP_METHOD(Test_NativeArray, testArray5) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_null));
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_null));
 	zephir_array_fast_append(a, ZEPHIR_GLOBAL(global_null));
@@ -121,7 +121,7 @@ PHP_METHOD(Test_NativeArray, testArray6) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "x", 1);
 	zephir_array_fast_append(a, _0);
@@ -146,7 +146,7 @@ PHP_METHOD(Test_NativeArray, testArray7) {
 	b = 2;
 	c = 3;
 	ZEPHIR_INIT_VAR(d);
-	array_init_size(d, 5);
+	array_init_size(d, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, a);
 	zephir_array_fast_append(d, _0);
@@ -171,7 +171,7 @@ PHP_METHOD(Test_NativeArray, testArray8) {
 	b = (double) (2);
 	c = (double) (3);
 	ZEPHIR_INIT_VAR(d);
-	array_init_size(d, 5);
+	array_init_size(d, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_DOUBLE(_0, a);
 	zephir_array_fast_append(d, _0);
@@ -196,7 +196,7 @@ PHP_METHOD(Test_NativeArray, testArray9) {
 	b = 0;
 	c = 1;
 	ZEPHIR_INIT_VAR(d);
-	array_init_size(d, 5);
+	array_init_size(d, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_BOOL(_0, a);
 	zephir_array_fast_append(d, _0);
@@ -224,7 +224,7 @@ PHP_METHOD(Test_NativeArray, testArray10) {
 	ZEPHIR_INIT_VAR(c);
 	ZVAL_STRING(c, "hello3", 1);
 	ZEPHIR_INIT_VAR(d);
-	array_init_size(d, 5);
+	array_init_size(d, 4);
 	zephir_array_fast_append(d, a);
 	zephir_array_fast_append(d, b);
 	zephir_array_fast_append(d, c);
@@ -239,7 +239,7 @@ PHP_METHOD(Test_NativeArray, testArray11) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -250,7 +250,7 @@ PHP_METHOD(Test_NativeArray, testArray11) {
 	ZVAL_LONG(_0, 3);
 	zephir_array_fast_append(a, _0);
 	ZEPHIR_INIT_VAR(b);
-	array_init_size(b, 5);
+	array_init_size(b, 4);
 	ZEPHIR_INIT_BNVAR(_0);
 	ZVAL_LONG(_0, 4);
 	zephir_array_fast_append(b, _0);
@@ -275,7 +275,7 @@ PHP_METHOD(Test_NativeArray, testArray12) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -302,7 +302,7 @@ PHP_METHOD(Test_NativeArray, testArray13) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_index_stringl(a, 1, SL("hello1"), 1);
 	add_index_stringl(a, 2, SL("hello2"), 1);
 	add_index_stringl(a, 3, SL("hello3"), 1);
@@ -317,7 +317,7 @@ PHP_METHOD(Test_NativeArray, testArray14) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("hello1"), 1);
 	add_assoc_long_ex(a, SS("hello2"), 2);
 	add_assoc_long_ex(a, SS("hello3"), 3);
@@ -332,7 +332,7 @@ PHP_METHOD(Test_NativeArray, testArray15) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	zephir_array_update_string(&a, SL("hello1"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&a, SL("hello2"), &ZEPHIR_GLOBAL(global_false), PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&a, SL("hello3"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
@@ -347,7 +347,7 @@ PHP_METHOD(Test_NativeArray, testArray16) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_assoc_double_ex(a, SS("hello1"), 1.0);
 	add_assoc_double_ex(a, SS("hello2"), 2.0);
 	add_assoc_double_ex(a, SS("hello3"), 3.0);
@@ -362,7 +362,7 @@ PHP_METHOD(Test_NativeArray, testArray17) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	zephir_array_update_string(&a, SL("hello1"), &ZEPHIR_GLOBAL(global_null), PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&a, SL("hello2"), &ZEPHIR_GLOBAL(global_null), PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&a, SL("hello3"), &ZEPHIR_GLOBAL(global_null), PH_COPY | PH_SEPARATE);
@@ -377,7 +377,7 @@ PHP_METHOD(Test_NativeArray, testArray18) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_assoc_stringl_ex(a, SS("hello1"), SL("a"), 1);
 	add_assoc_stringl_ex(a, SS("hello2"), SL("b"), 1);
 	add_assoc_stringl_ex(a, SS("hello3"), SL("c"), 1);
@@ -392,7 +392,7 @@ PHP_METHOD(Test_NativeArray, testArray19) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_index_bool(a, 0, 1);
 	zephir_array_update_long(&a, 0, &ZEPHIR_GLOBAL(global_true), PH_COPY, "test/nativearray.zep", 147);
 	add_index_bool(a, 1, 0);
@@ -410,7 +410,7 @@ PHP_METHOD(Test_NativeArray, testArray20) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_index_double(a, 0, 1.0);
 	add_index_double(a, 1, 2.0);
 	add_index_double(a, 2, 3.0);
@@ -425,7 +425,7 @@ PHP_METHOD(Test_NativeArray, testArray21) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	zephir_array_update_long(&a, 0, &ZEPHIR_GLOBAL(global_null), PH_COPY, "test/nativearray.zep", 161);
 	zephir_array_update_long(&a, 1, &ZEPHIR_GLOBAL(global_null), PH_COPY, "test/nativearray.zep", 161);
 	zephir_array_update_long(&a, 2, &ZEPHIR_GLOBAL(global_null), PH_COPY, "test/nativearray.zep", 161);
@@ -440,7 +440,7 @@ PHP_METHOD(Test_NativeArray, testArray22) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_index_long(a, 0, 4);
 	add_index_long(a, 1, 5);
 	add_index_long(a, 2, 6);
@@ -457,7 +457,7 @@ PHP_METHOD(Test_NativeArray, testArray23) {
 
 	b = 0;
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, b);
 	zephir_array_update_long(&a, 0, &_0, PH_COPY, "test/nativearray.zep", 177);
@@ -480,7 +480,7 @@ PHP_METHOD(Test_NativeArray, testArray24) {
 
 	b = 0.0;
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_DOUBLE(_0, b);
 	zephir_array_update_long(&a, 0, &_0, PH_COPY, "test/nativearray.zep", 186);
@@ -503,7 +503,7 @@ PHP_METHOD(Test_NativeArray, testArray25) {
 
 	b = 0;
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_BOOL(_0, b);
 	zephir_array_update_long(&a, 0, &_0, PH_COPY, "test/nativearray.zep", 195);
@@ -526,7 +526,7 @@ PHP_METHOD(Test_NativeArray, testArray26) {
 	ZEPHIR_INIT_VAR(b);
 	ZVAL_NULL(b);
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	zephir_array_update_long(&a, 0, &b, PH_COPY, "test/nativearray.zep", 204);
 	zephir_array_update_long(&a, 1, &b, PH_COPY, "test/nativearray.zep", 204);
 	zephir_array_update_long(&a, 2, &b, PH_COPY, "test/nativearray.zep", 204);
@@ -544,7 +544,7 @@ PHP_METHOD(Test_NativeArray, testArray27) {
 	ZEPHIR_INIT_VAR(b);
 	ZVAL_STRING(b, "hello", 1);
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	zephir_array_update_long(&a, 0, &b, PH_COPY, "test/nativearray.zep", 213);
 	zephir_array_update_long(&a, 1, &b, PH_COPY, "test/nativearray.zep", 213);
 	zephir_array_update_long(&a, 2, &b, PH_COPY, "test/nativearray.zep", 213);
@@ -562,7 +562,7 @@ PHP_METHOD(Test_NativeArray, testArray28) {
 	ZEPHIR_INIT_VAR(b);
 	ZVAL_STRING(b, "hello", 1);
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	zephir_array_update_long(&a, 0, &b, PH_COPY, "test/nativearray.zep", 222);
 	zephir_array_update_long(&a, 1, &b, PH_COPY, "test/nativearray.zep", 222);
 	zephir_array_update_long(&a, 2, &b, PH_COPY, "test/nativearray.zep", 222);
@@ -608,7 +608,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess1) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -630,7 +630,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess2) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);
@@ -647,7 +647,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess3) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -671,7 +671,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess4) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);
@@ -689,7 +689,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess5) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);
@@ -707,7 +707,7 @@ PHP_METHOD(Test_NativeArray, testArrayAccess6) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);
@@ -845,7 +845,7 @@ PHP_METHOD(Test_NativeArray, testArrayUpdate1) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -870,7 +870,7 @@ PHP_METHOD(Test_NativeArray, testArrayUpdate2) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -896,7 +896,7 @@ PHP_METHOD(Test_NativeArray, testArrayUpdate3) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(a, _0);
@@ -925,7 +925,7 @@ PHP_METHOD(Test_NativeArray, testArrayUpdate4) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
-	array_init_size(a, 5);
+	array_init_size(a, 4);
 	add_assoc_long_ex(a, SS("a"), 1);
 	add_assoc_long_ex(a, SS("b"), 2);
 	add_assoc_long_ex(a, SS("c"), 3);
@@ -1165,7 +1165,7 @@ PHP_METHOD(Test_NativeArray, issue110) {
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(byteUnits);
-	array_init_size(byteUnits, 11);
+	array_init_size(byteUnits, 10);
 	add_assoc_long_ex(byteUnits, SS("B"), 0);
 	add_assoc_long_ex(byteUnits, SS("K"), 10);
 	add_assoc_long_ex(byteUnits, SS("M"), 20);

--- a/ext/test/oo.c
+++ b/ext/test/oo.c
@@ -173,3 +173,20 @@ PHP_METHOD(Test_Oo, testInstance10) {
 
 }
 
+PHP_METHOD(Test_Oo, testInstance11) {
+
+	zval *o, *_0, *_1;
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_INIT_VAR(o);
+	object_init_ex(o, test_oo_ooconstructparams_ce);
+	ZEPHIR_INIT_VAR(_0);
+	ZVAL_LONG(_0, 1);
+	ZEPHIR_INIT_VAR(_1);
+	ZVAL_LONG(_1, 2);
+	zephir_call_method_p2_noret(o, "__construct", _0, _1);
+	RETURN_CCTOR(o);
+
+}
+

--- a/ext/test/oo.h
+++ b/ext/test/oo.h
@@ -13,6 +13,7 @@ PHP_METHOD(Test_Oo, testInstance7);
 PHP_METHOD(Test_Oo, testInstance8);
 PHP_METHOD(Test_Oo, testInstance9);
 PHP_METHOD(Test_Oo, testInstance10);
+PHP_METHOD(Test_Oo, testInstance11);
 
 ZEPHIR_INIT_FUNCS(test_oo_method_entry) {
 	PHP_ME(Test_Oo, testInstance1, NULL, ZEND_ACC_PUBLIC)
@@ -25,5 +26,6 @@ ZEPHIR_INIT_FUNCS(test_oo_method_entry) {
 	PHP_ME(Test_Oo, testInstance8, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Oo, testInstance9, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Oo, testInstance10, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Oo, testInstance11, NULL, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };

--- a/ext/test/oo/ooparams.c
+++ b/ext/test/oo/ooparams.c
@@ -12,8 +12,9 @@
 #include <Zend/zend_interfaces.h>
 
 #include "kernel/main.h"
-#include "kernel/operators.h"
+#include "kernel/fcall.h"
 #include "kernel/memory.h"
+#include "kernel/operators.h"
 #include "ext/spl/spl_exceptions.h"
 #include "kernel/exception.h"
 
@@ -27,6 +28,30 @@ ZEPHIR_INIT_CLASS(Test_Oo_OoParams) {
 
 
 	return SUCCESS;
+
+}
+
+PHP_METHOD(Test_Oo_OoParams, createThisClassWithoutWriteCurrentNamespace) {
+
+	ZEPHIR_MM_GROW();
+
+	object_init_ex(return_value, test_oo_ooparams_ce);
+	if (zephir_has_constructor(return_value TSRMLS_CC)) {
+		zephir_call_method_noret(return_value, "__construct");
+	}
+	RETURN_MM();
+
+}
+
+PHP_METHOD(Test_Oo_OoParams, createOtherClassWithoutWriteCurrentNamespace) {
+
+	ZEPHIR_MM_GROW();
+
+	object_init_ex(return_value, test_oo_oodynamica_ce);
+	if (zephir_has_constructor(return_value TSRMLS_CC)) {
+		zephir_call_method_noret(return_value, "__construct");
+	}
+	RETURN_MM();
 
 }
 

--- a/ext/test/oo/ooparams.h
+++ b/ext/test/oo/ooparams.h
@@ -3,6 +3,8 @@ extern zend_class_entry *test_oo_ooparams_ce;
 
 ZEPHIR_INIT_CLASS(Test_Oo_OoParams);
 
+PHP_METHOD(Test_Oo_OoParams, createThisClassWithoutWriteCurrentNamespace);
+PHP_METHOD(Test_Oo_OoParams, createOtherClassWithoutWriteCurrentNamespace);
 PHP_METHOD(Test_Oo_OoParams, setAge);
 PHP_METHOD(Test_Oo_OoParams, setAverage);
 PHP_METHOD(Test_Oo_OoParams, setName);
@@ -65,6 +67,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_test_oo_ooparams_setconstaverage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 
 ZEPHIR_INIT_FUNCS(test_oo_ooparams_method_entry) {
+	PHP_ME(Test_Oo_OoParams, createThisClassWithoutWriteCurrentNamespace, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Oo_OoParams, createOtherClassWithoutWriteCurrentNamespace, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Oo_OoParams, setAge, arginfo_test_oo_ooparams_setage, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Oo_OoParams, setAverage, arginfo_test_oo_ooparams_setaverage, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Oo_OoParams, setName, arginfo_test_oo_ooparams_setname, ZEND_ACC_PUBLIC)

--- a/ext/test/oo/propertyaccess.c
+++ b/ext/test/oo/propertyaccess.c
@@ -40,7 +40,7 @@ PHP_METHOD(Test_Oo_PropertyAccess, __construct) {
 	ZEPHIR_INIT_VAR(test);
 	object_init(test);
 	ZEPHIR_INIT_VAR(_0);
-	array_init_size(_0, 7);
+	array_init_size(_0, 6);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_LONG(_1, 1);
 	zephir_array_fast_append(_0, _1);

--- a/ext/test/regexdna.c
+++ b/ext/test/regexdna.c
@@ -46,7 +46,7 @@ PHP_METHOD(Test_RegexDNA, process) {
 
 
 	ZEPHIR_INIT_VAR(variants);
-	array_init_size(variants, 11);
+	array_init_size(variants, 10);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "agggtaaa|tttaccct", 1);
 	zephir_array_fast_append(variants, _0);

--- a/ext/test/router.c
+++ b/ext/test/router.c
@@ -113,7 +113,7 @@ PHP_METHOD(Test_Router, __construct) {
 		ZEPHIR_INIT_VAR(_3);
 		object_init_ex(_3, test_router_route_ce);
 		ZEPHIR_INIT_NVAR(_2);
-		array_init_size(_2, 5);
+		array_init_size(_2, 4);
 		add_assoc_long_ex(_2, SS("controller"), 1);
 		add_assoc_long_ex(_2, SS("action"), 2);
 		add_assoc_long_ex(_2, SS("params"), 3);

--- a/ext/test/vars.c
+++ b/ext/test/vars.c
@@ -38,7 +38,7 @@ PHP_METHOD(Test_Vars, testVarDump) {
 	ZEPHIR_INIT_VAR(a);
 	ZVAL_STRING(a, "hello", 1);
 	ZEPHIR_INIT_VAR(ar);
-	array_init_size(ar, 5);
+	array_init_size(ar, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(ar, _0);
@@ -61,7 +61,7 @@ PHP_METHOD(Test_Vars, testVarExport) {
 	ZEPHIR_INIT_VAR(a);
 	ZVAL_STRING(a, "hello", 1);
 	ZEPHIR_INIT_VAR(ar);
-	array_init_size(ar, 5);
+	array_init_size(ar, 4);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
 	zephir_array_fast_append(ar, _0);

--- a/test/oo.zep
+++ b/test/oo.zep
@@ -86,4 +86,11 @@ class Oo
 		let o = Test\Oo\OoDynamicB::getNew();
 		return o;
 	}
+
+	public function testInstance11()
+	{
+		var o;
+		let o = new Oo\OoConstructParams(1, 2);
+		return o;
+	}
 }

--- a/test/oo/oodynamica.zep
+++ b/test/oo/oodynamica.zep
@@ -7,11 +7,11 @@ namespace Test\Oo;
 
 class OoDynamicA
 {
-  public static function getNew()
-  {
-    var className, fullClassName;
-    let className = get_called_class();
-    let fullClassName = "\\" . className;
-    return new {fullClassName}();
-  }
+	public static function getNew()
+	{
+		var className, fullClassName;
+		let className = get_called_class();
+		let fullClassName = "\\" . className;
+		return new {fullClassName}();
+	}
 }

--- a/test/oo/ooparams.zep
+++ b/test/oo/ooparams.zep
@@ -7,6 +7,15 @@ namespace Test\Oo;
 
 class OoParams
 {
+	public function createThisClassWithoutWriteCurrentNamespace()
+	{
+		return new OoParams();
+	}
+
+	public function createOtherClassWithoutWriteCurrentNamespace()
+	{
+		return new OoDynamicA();
+	}
 
 	public function setAge(int age)
 	{

--- a/unit-tests/oo.php
+++ b/unit-tests/oo.php
@@ -38,3 +38,7 @@ assert($obj9 instanceOf Test\Oo\OoDynamicA);
 $obj10 = $t->testInstance10();
 assert(is_object($obj10));
 assert($obj10 instanceOf Test\Oo\OoDynamicB);
+
+$obj = $t->testInstance11();
+assert(is_object($obj));
+assert($obj instanceof Test\Oo\OoConstructParams);

--- a/unit-tests/params.php
+++ b/unit-tests/params.php
@@ -2,6 +2,9 @@
 
 $t = new Test\Oo\OoParams();
 
+assert($t->createThisClassWithoutWriteCurrentNamespace() instanceof Test\Oo\OoParams);
+assert($t->createOtherClassWithoutWriteCurrentNamespace() instanceof Test\Oo\OoDynamicA);
+
 assert($t->setAge(17) === 17);
 assert($t->setAge("17") === 17);
 assert($t->setAge(17.0) === 17);


### PR DESCRIPTION
- implement
- added tests

Example

``` zephir
class EntityManager
{
    protected unitOfWork;

    public function __construct()
    {
        // before this commit i need to write all namespace \Phalcon\ORM\UnitOfWork
        let this->unitOfWork = new UnitOfWork();
    }
}
```

Review me @phalcon 
