### PR TITLE
Added php5.6 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
 
 before_install:
  - ./unit-tests/ci/before_install.sh


### PR DESCRIPTION
May be we should allow failures for unstable php 5.6 version.
But now, as you can see tests passed
