### PR TITLE
Set dynamic property

### DIFF
--- a/test/oo/dynamicprop.zep
+++ b/test/oo/dynamicprop.zep
@@ -1,0 +1,13 @@
+/**
+ *
+ */
+
+namespace Test\Oo;
+
+class DynamicProp {
+
+	public function setProperty(string property) -> void {
+		let this->{property} = 10;
+	}
+	
+}


### PR DESCRIPTION
This example gives compile time error.

Zephir\CompilerException: Unknown type int 
      let this->{property} = 10;
    ---------------------------^
