### PR TITLE
Updated Library/ClassMethod add method hasChildReturnStatement

### DIFF
--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -1832,7 +1832,7 @@ class ClassMethod
              */
             $lastType = $this->_statements->getLastStatementType();
 
-            if ($lastType != 'return' && $lastType != 'throw') {
+            if ($lastType != 'return' && $lastType != 'throw' && !$this->hasChildReturnStatementType($this->_statements->getLastStatement())) {
 
                 if ($symbolTable->getMustGrownStack()) {
                     $compilationContext->headersManager->add('kernel/memory');
@@ -1866,5 +1866,23 @@ class ClassMethod
         $codePrinter->clear();
 
         return null;
+    }
+
+    public function hasChildReturnStatementType($statement)
+    {
+        if (!isset($statement['statements']) || !is_array($statement['statements'])) {
+            return false;
+        }
+
+        $statements = $statement['statements'];
+        foreach ($statements as $item) {
+            $type = isset($item['type']) ? $item['type'] : null;
+            if ($type == 'return' || $type == 'throw') {
+                return true;
+            } else {
+                return $this->hasChildReturnStatementType($item);
+            }
+        }
+        return false;
     }
 }

--- a/Library/StatementsBlock.php
+++ b/Library/StatementsBlock.php
@@ -321,4 +321,14 @@ class StatementsBlock
     {
         return $this->_lastStatement['type'];
     }
+
+    /**
+     * Returns the last statement executed
+     *
+     * @return array
+     */
+    public function getLastStatement()
+    {
+        return $this->_lastStatement;
+    }
 }

--- a/test/returns.zep
+++ b/test/returns.zep
@@ -21,4 +21,13 @@ class Returns
 	{
 		return (int) false;
 	}
+
+	public function testReturnCast4() -> int
+	{
+		if true {
+			return (int)1;
+		} else {
+			return (int)0;
+		}
+	}
 }


### PR DESCRIPTION
Support child statement return.

``` php
class ClassReturn
{

        public function say(int i) -> string|null {
                if i <= 0 {
                        return null;
                } else {
                        return "return";
                }
        }
}
```
