### PR TITLE
Remove unnecessary sudo inside install script

### DIFF
--- a/install
+++ b/install
@@ -28,7 +28,7 @@ do
     ZEPHIRDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     sed "s#%ZEPHIRDIR%#$ZEPHIRDIR#g" bin/zephir > bin/zephir-cmd
     chmod 755 bin/zephir-cmd
-    sudo cp bin/zephir-cmd /usr/local/bin/zephir
+    cp bin/zephir-cmd /usr/local/bin/zephir
     rm bin/zephir-cmd
     exit 0
   fi


### PR DESCRIPTION
This will make the install script compatible with automated configuration tools,such as puppet (Including the puppet module which i have created)
