### PR TITLE
Fix compilation failing for runtime

### DIFF
--- a/runtime/base.c
+++ b/runtime/base.c
@@ -99,7 +99,7 @@ static void zephir_scanner_error_msg(zephir_parser_status *parser_status){
 /**
  * Parses a program returning an intermediate array representation
  */
-int zephir_parse_program(zval **return_value, char *program, unsigned int program_length, char *file_path, zval **error_msg TSRMLS_DC) {
+int zephir_parse_program(zval **return_value, char *program, unsigned int program_length, const char *file_path, zval **error_msg TSRMLS_DC) {
 
 	char *error;
 	zephir_scanner_state *state;

--- a/runtime/config.m4
+++ b/runtime/config.m4
@@ -13,7 +13,7 @@ if test "$PHP_ZEPHIR" = "yes"; then
 	LLVM_LDFLAGS=`llvm-config-3.3 --libs --ldflags core analysis executionengine jit interpreter native`
 	LLVM_CFLAGS=`llvm-config-3.3 --cflags`
 	LDFLAGS="$LDFLAGS -Wl,-rpath $LLVM_LDFLAGS"
-	CFLAGS="$CFLAGS -Wl,-rpath $LLVM_CFLAGS -O0 -g3"
+	CFLAGS="$CFLAGS -Wl,-rpath $LLVM_CFLAGS -O0 -g3 -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS"
 
 	dnl Check for stdc++:
 	LIBNAME=stdc++

--- a/runtime/parser.c
+++ b/runtime/parser.c
@@ -7624,7 +7624,7 @@ static void zephir_scanner_error_msg(zephir_parser_status *parser_status){
 /**
  * Parses a program returning an intermediate array representation
  */
-int zephir_parse_program(zval **return_value, char *program, unsigned int program_length, char *file_path, zval **error_msg TSRMLS_DC) {
+int zephir_parse_program(zval **return_value, char *program, unsigned int program_length, const char *file_path, zval **error_msg TSRMLS_DC) {
 
 	char *error;
 	zephir_scanner_state *state;

--- a/runtime/zephir.c
+++ b/runtime/zephir.c
@@ -159,8 +159,9 @@ static void zephir_compile_program(zval *program TSRMLS_DC)
 /**
  * Opens a file and parses/compiles it using the Zephir parse
  */
-static void zephir_parse_file(char *file_name TSRMLS_DC)
+static void zephir_parse_file(const char *file_name TSRMLS_DC)
 {
+    char *file_name_pass = (char*) file_name;
 	char *contents;
 	php_stream *stream;
 	int len;
@@ -170,7 +171,7 @@ static void zephir_parse_file(char *file_name TSRMLS_DC)
 
 	context = php_stream_context_from_zval(zcontext, 0);
 
-	stream = php_stream_open_wrapper_ex(file_name, "rb", 0 | REPORT_ERRORS, NULL, context);
+	stream = php_stream_open_wrapper_ex(file_name_pass, "rb", 0 | REPORT_ERRORS, NULL, context);
 	if (!stream) {
 		return;
 	}

--- a/runtime/zephir.h
+++ b/runtime/zephir.h
@@ -78,6 +78,6 @@ typedef struct _zephir_compiled_expr {
 #define ZEPHIR_PARSING_OK 1
 #define ZEPHIR_PARSING_FAILED 0
 
-int zephir_parse_program(zval **return_value, char *program, unsigned int program_length, char *file_path, zval **error_message TSRMLS_DC);
+int zephir_parse_program(zval **return_value, char *program, unsigned int program_length, const char *file_path, zval **error_message TSRMLS_DC);
 
 #endif


### PR DESCRIPTION
When i try to compile runtime lib for next contributing i have 2 problems
1 fail note on const char\* and char\* but whe i fix declaration i have problem with php_stream_open_wrapper_ex
2 

```
/usr/local/include/llvm/Support/DataTypes.h:48:3: erreur: #error "Must #define __STDC_LIMIT_MACROS before #including Support/DataTypes.h"
/usr/local/include/llvm/Support/DataTypes.h:52:3: erreur: #error "Must #define __STDC_CONSTANT_MACROS before " "#including Support/DataTypes.h"
```
