### PR TITLE
No need to redeclare interface methods in the abstract

### DIFF
--- a/Library/Commands/CommandAbstract.php
+++ b/Library/Commands/CommandAbstract.php
@@ -33,25 +33,6 @@ abstract class CommandAbstract implements CommandInterface
     private $_parameters = null;
 
     /**
-     * Command provided by this command
-     *
-     * @return string
-     */
-    abstract public function getCommand();
-
-    /**
-     * Command usage
-     *
-     * @return string
-     */
-    abstract public function getUsage();
-
-    /**
-     * @return string
-     */
-    abstract public function getDescription();
-
-    /**
      * Returns parameter named $name if specified
      * on the commmand line else null
      *


### PR DESCRIPTION
The abstract functions getCommand, getUsage and getDescription are already declared in the CommandInterface which is implemented by the CommandAbstract.
