### PR TITLE
Be able to look for php.ini file

### DIFF
--- a/bin/zephir
+++ b/bin/zephir
@@ -32,4 +32,9 @@ if [ ! -r $ZEPHIRDIR/bin/zephir-parser ]; then
     esac
 fi
 
-php $ZEPHIRDIR/compiler.php $*
+if [[ $1 && $2 && $3 && "$1"=="-c" ]]; then
+    php -c $2 $ZEPHIRDIR/compiler.php ${*:3}
+else
+    php $ZEPHIRDIR/compiler.php $*
+fi
+


### PR DESCRIPTION
In PHP 5.3, Zephir requires more memory about 256MB to compile Phalcon 2.0.

It will be possible to pass php.ini and allow higher mem usage then 128MB, because some builds of [php5-phalcon-zephir](https://build.opensuse.org/package/show/home:mruz/php5-phalcon-zephir) for openSUSE are failed.

```
../bin/zephir -c php.ini generate
```
