### PR TITLE
Fixed checkInterfaceImplements

### DIFF
--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -608,7 +608,7 @@ class ClassDefinition
 
             if ($method->hasParameters()) {
                 $implementedMethod = $classDefinition->getMethod($method->getName());
-                if ($implementedMethod->getNumberOfRequiredParameters() != $method->getNumberOfRequiredParameters()) {
+                if ($implementedMethod->getNumberOfRequiredParameters() > $method->getNumberOfRequiredParameters() || $implementedMethod->getNumberOfParameters() < $method->getNumberOfParameters()) {
                     throw new CompilerException("Class " . $classDefinition->getCompleteName() . "::" . $method->getName() . "() does not have the same number of required parameters in interface: " . $interfaceDefinition->getCompleteName());
                 }
             }


### PR DESCRIPTION
Error message. (for Pahlcon)

Zephir\CompilerException: Class Phalcon\Logger\Adapter\File::log() does not have the same number of required parameters in interface: Phalcon\Logger\AdapterInterface

```
namespace Phalcon\Logger;
interface AdapterInterface
{
    public function log(type, string message, array context);
}
```

```
namespace Phalcon\Logger;
abstract class Adapter
{
    public function log(type, string message=null, array context=null) -> <\Phalcon\Logger\AdapterInterface>
}
```
