### PR TITLE
Stubs\Generator implement array type support in method parameters declarations

### DIFF
--- a/Library/Stubs/Generator.php
+++ b/Library/Stubs/Generator.php
@@ -215,8 +215,7 @@ EOF;
                 $paramStr = '$' . $parameter['name'];
 
                 if (isset($parameter['default'])) {
-                    $paramStr .= ' = ';
-                    $paramStr .= $this->wrapPHPValue($parameter);
+                    $paramStr .= ' = ' . $this->wrapPHPValue($parameter);
                 }
 
                 $parameters[] = $paramStr;


### PR DESCRIPTION
Zephir

``` zep
class A {
    public function test(array type = [1, "test", 2, null, true]) {
        //todo
    }
}
```

In PHP stubs

``` php
class A {
    public function test(array $type = array(1, "test", 2, null, true)) {
        //todo
    }
}
```
