### PR TITLE
Fix bug generate namespace addslashes

### DIFF
--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -884,7 +884,7 @@ class ClassDefinition
                                     case 'variable':
                                         $value = $parameter['cast']['value'];
 
-                                        $codePrinter->output("\t" . 'ZEND_ARG_OBJ_INFO(0, ' . $parameter['name'] . ', ' . $compilationContext->getFullName($value) . ', ' . (isset($parameter['default']) ? 1 : 0) . ')');
+                                        $codePrinter->output("\t" . 'ZEND_ARG_OBJ_INFO(0, ' . $parameter['name'] . ', ' . $compilationContext->getFullName($value, TRUE) . ', ' . (isset($parameter['default']) ? 1 : 0) . ')');
                                         break;
                                     default:
                                         throw new Exception('Unexpected exception');

--- a/Library/CompilationContext.php
+++ b/Library/CompilationContext.php
@@ -177,8 +177,12 @@ class CompilationContext
      * @param string $className
      * @return string
      */
-    public function getFullName($className)
+    public function getFullName($className, $addslashes = FALSE)
     {
-        return Utils::getFullName($className, $this->classDefinition->getNamespace(), $this->aliasManager);
+		$fullname = Utils::getFullName($className, $this->classDefinition->getNamespace(), $this->aliasManager);
+		if ($addslashes) {
+			$fullname = addslashes($fullname);
+		}
+        return $fullname;
     }
 }


### PR DESCRIPTION
Before:

``` c
    ZEND_ARG_OBJ_INFO(0, validation, Phalcon\Validation, 0)
```

after:

``` c
    ZEND_ARG_OBJ_INFO(0, validation, Phalcon\\Validation, 0)
```
