### PR TITLE
Added "zend_ce_traversable" to ClassDefinition

### DIFF
--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -1035,6 +1035,9 @@ class ClassDefinition
             /**
              * Zend interfaces (Zend/zend_interfaces.h)
              */
+            case 'traversable':
+                $classEntry = 'zend_ce_traversable';
+                break;
             case 'iterator':
                 $classEntry = 'zend_ce_iterator';
                 break;

--- a/test/oo/oonativeimplements.zep
+++ b/test/oo/oonativeimplements.zep
@@ -7,6 +7,7 @@ namespace Test\Oo;
 
 class OoNativeImplements implements
 							\Countable,
+							\Traversable,
 							\Iterator,
 							\OuterIterator,
 							\RecursiveIterator,


### PR DESCRIPTION
Added "zend_ce_traversable" to ClassDefinition from https://github.com/php/php-src/blob/e5e9d8346f50d406f4e8ed8431b7c917663a32c3/Zend/zend_interfaces.c#L26
