### PR TITLE
ClassDefintion fix incorrect way to set abstract for interface

### DIFF
--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -238,7 +238,7 @@ class ClassDefinition
      */
     public function isAbstract()
     {
-        return $this->abstract || $this->isInterface();
+        return $this->abstract;
     }
 
     /**
@@ -909,7 +909,7 @@ class ClassDefinition
                 /**
                  * We don't check if abstract classes implement the methods in their interfaces
                  */
-                if (!$this->isAbstract()) {
+                if (!$this->isAbstract() && !$this->isInterface()) {
                     $this->checkInterfaceImplements($this, $classInterfaceDefinition);
                 }
 
@@ -917,7 +917,7 @@ class ClassDefinition
             }
         }
 
-        if (!$this->isAbstract()) {
+        if (!$this->isAbstract() && !$this->isInterface()) {
 
             /**
              * Interfaces in extended classes may have

--- a/ext/test/assign.zep.c
+++ b/ext/test/assign.zep.c
@@ -1630,8 +1630,8 @@ PHP_METHOD(Test_Assign, testConstantKeyAssign) {
 	ZEPHIR_INIT_VAR(elements);
 	array_init_size(elements, 5);
 	add_assoc_long_ex(elements, SS("abc"), 1);
-	add_index_long(elements, 14, 7);
-	add_index_long(elements, 15, 8);
+	add_index_long(elements, 131072, 131079);
+	add_index_long(elements, 131073, 131080);
 	ZEPHIR_MM_RESTORE();
 
 }

--- a/ext/test/references.zep.c
+++ b/ext/test/references.zep.c
@@ -26,15 +26,15 @@ ZEPHIR_INIT_CLASS(Test_References) {
 
 PHP_METHOD(Test_References, assignByRef) {
 
-	zval *a = NULL, *b = NULL;
+	zval *a, *b = NULL;
 
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_VAR(a);
 	ZVAL_LONG(a, 100);
 	ZEPHIR_MAKE_REFERENCE(b, a);
-	ZEPHIR_INIT_NVAR(a);
-	ZVAL_LONG(a, 50);
+	ZEPHIR_INIT_NVAR(b);
+	ZVAL_LONG(b, 50);
 	RETURN_MM_BOOL(ZEPHIR_IS_EQUAL(a, b));
 
 }


### PR DESCRIPTION
- In stubs interfaces is `abstract interfaces`
- It is not good way

For example
Before https://gist.github.com/ovr/bed9b5fff119f34d826e
After https://gist.github.com/ovr/b8b6aeb954ef82a6e331
