### PR TITLE
Implement array-append on static properties

### DIFF
--- a/Library/Statements/Let/StaticPropertyAppend.php
+++ b/Library/Statements/Let/StaticPropertyAppend.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2014 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Zephir\Statements\Let;
+
+use Zephir\CompilationContext;
+use Zephir\CompilerException;
+use Zephir\Variable as ZephirVariable;
+use Zephir\Detectors\ReadDetector;
+use Zephir\Expression;
+use Zephir\CompiledExpression;
+use Zephir\Compiler;
+use Zephir\Utils;
+use Zephir\GlobalConstant;
+
+/**
+ * StaticPropertyAppend
+ *
+ * Updates object properties dynamically
+ */
+class StaticPropertyAppend extends ArrayIndex
+{
+    /**
+     * Compiles x::y[a][b][] = {expr} (multiple offset assignment)
+     *
+     * @param string $variable
+     * @param CompiledExpression $resolvedExpr
+     * @param CompilationContext $compilationContext,
+     * @param array $statement
+     */
+    protected function _assignStaticPropertyArrayMultipleIndex($classEntry, $property, CompiledExpression $resolvedExpr, CompilationContext $compilationContext, $statement)
+    {
+        $codePrinter = $compilationContext->codePrinter;
+
+        $property = $statement['property'];
+        $compilationContext->headersManager->add('kernel/object');
+
+        /**
+         * Create a temporal zval (if needed)
+         */
+        $variableExpr = $this->_getResolvedArrayItem($resolvedExpr, $compilationContext);
+
+        $codePrinter->output('zephir_update_static_property_array_multi_ce(' . $classEntry .', SL("' . $property . '"), &' . $variableExpr->getName() . ' TSRMLS_CC, SL("a"), 1);');
+
+        if ($variableExpr->isTemporal()) {
+            $variableExpr->setIdle(true);
+        }
+    }
+
+    /**
+     * Compiles ClassName::foo[index] = {expr}
+     *
+     * @param                    $className
+     * @param                    $property
+     * @param CompiledExpression $resolvedExpr
+     * @param CompilationContext $compilationContext
+     * @param array              $statement
+     *
+     * @throws CompilerException
+     * @internal param string $variable
+     */
+    public function assignStatic($className, $property, CompiledExpression $resolvedExpr, CompilationContext $compilationContext, $statement)
+    {
+
+        $compiler = $compilationContext->compiler;
+        if (!in_array($className, array('self', 'static', 'parent'))) {
+            $className = $compilationContext->getFullName($className);
+            if ($compiler->isClass($className)) {
+                $classDefinition = $compiler->getClassDefinition($className);
+            } else {
+                if ($compiler->isInternalClass($className)) {
+                    $classDefinition = $compiler->getInternalClassDefinition($className);
+                } else {
+                    throw new CompilerException("Cannot locate class '" . $className . "'", $statement);
+                }
+            }
+        } else {
+            if (in_array($className, array('self', 'static'))) {
+                $classDefinition = $compilationContext->classDefinition;
+            } else {
+                if ($className == 'parent') {
+                    $classDefinition = $compilationContext->classDefinition;
+                    $extendsClass = $classDefinition->getExtendsClass();
+                    if (!$extendsClass) {
+                        throw new CompilerException('Cannot assign static property "' . $property . '" on parent because class ' . $classDefinition->getCompleteName() . ' does not extend any class', $statement);
+                    } else {
+                        $classDefinition = $classDefinition->getExtendsClassDefinition();
+                    }
+                }
+            }
+        }
+
+        if (!$classDefinition->hasProperty($property)) {
+            throw new CompilerException("Class '" . $classDefinition->getCompleteName() . "' does not have a property called: '" . $property . "'", $statement);
+        }
+
+        /** @var $propertyDefinition ClassProperty */
+        $propertyDefinition = $classDefinition->getProperty($property);
+        if (!$propertyDefinition->isStatic()) {
+            throw new CompilerException("Cannot access non-static property '" . $classDefinition->getCompleteName() . '::' . $property . "'", $statement);
+        }
+
+        if ($propertyDefinition->isPrivate()) {
+            if ($classDefinition != $compilationContext->classDefinition) {
+                throw new CompilerException("Cannot access private static property '" . $classDefinition->getCompleteName() . '::' . $property . "' out of its declaring context", $statement);
+            }
+        }
+
+        $compilationContext->headersManager->add('kernel/object');
+        $classEntry = $classDefinition->getClassEntry($compilationContext);
+        $this->_assignStaticPropertyArrayMultipleIndex($classEntry, $property, $resolvedExpr, $compilationContext, $statement);
+    }
+}

--- a/Library/Statements/LetStatement.php
+++ b/Library/Statements/LetStatement.php
@@ -41,6 +41,7 @@ use Zephir\Statements\Let\ObjectPropertyArrayIndexAppend as LetObjectPropertyArr
 use Zephir\Statements\Let\ObjectPropertyIncr as LetObjectPropertyIncr;
 use Zephir\Statements\Let\ObjectPropertyDecr as LetObjectPropertyDecr;
 use Zephir\Statements\Let\StaticProperty as LetStaticProperty;
+use Zephir\Statements\Let\StaticPropertyAppend as LetStaticPropertyAppend;
 use Zephir\Statements\Let\StaticPropertyArrayIndex as LetStaticPropertyArrayIndex;
 use Zephir\Statements\Let\StaticPropertyArrayIndexAppend as LetStaticPropertyArrayIndexAppend;
 use Zephir\Statements\Let\Decr as LetDecr;
@@ -175,7 +176,8 @@ class LetStatement extends StatementAbstract
                     break;
 
                 case 'static-property-append':
-                    /* @todo, implement this */
+                    $let = new LetStaticPropertyAppend();
+                    $let->assignStatic($variable, $assignment['property'], $resolvedExpr, $compilationContext, $assignment);
                     break;
 
                 case 'static-property-array-index':

--- a/test/assign.zep
+++ b/test/assign.zep
@@ -289,7 +289,7 @@ class Assign
 			a = b;
 		return a;
 	}
-	
+
 	public function testAssign37()
 	{
 		var v = "abc";
@@ -297,14 +297,14 @@ class Assign
 		let arr = [
 			"a": ["b_key": "b_val", "b": []]
 		];
-		
+
 		let arr["a"]["b"]["d_key"] = "d_val";
 		let arr["s"] = 1;
 		let arr["a"]["b"]["c"]["d"]["e"] = "f";
 		let arr[1] = [
 			2: [3: 4]
 		];
-		
+
 		let arr[1][2][5] = 6;
 		let arr[1][2][v] = v;
 		return arr;
@@ -599,7 +599,7 @@ class Assign
 		let temp3 = count(this->myArray);
 		return this->myArray;
 	}
-	
+
 	public function testPropertyArray14()
 	{
 		var v = "abc";
@@ -610,7 +610,7 @@ class Assign
 		let this->myArray[1] = [
 			2: [3: 4]
 		];
-		
+
 		let this->myArray["s"] = 1;
 		let this->myArray["a"]["b"]["c"]["d"]["e"] = "f";
 		let this->myArray[1][2][5] = 6;
@@ -692,6 +692,17 @@ class Assign
 		return self::testVarStatic;
 	}
 
+	public function testStaticPropertyArrayAppend()
+    {
+    	let self::testVarStatic = [];
+    	let self::testVarStatic[] = "test";
+    	let self::testVarStatic[] = 1;
+    	let self::testVarStatic[] = 1.5;
+    	let self::testVarStatic[] = false;
+    	let self::testVarStatic[] = [];
+    	return self::testVarStatic;
+    }
+
 	public function testStaticPropertyArrayMutli1()
 	{
 		let self::testVarStatic       = [];
@@ -733,7 +744,7 @@ class Assign
 		let self::testVarStatic[index][index] = [];
 		return self::testVarStatic;
 	}
-	
+
 	public function testStaticPropertyArrayMulti4()
 	{
 		var v = "abc";
@@ -744,7 +755,7 @@ class Assign
 		let self::testVarStatic[1] = [
 			2: [3: 4]
 		];
-		
+
 		let self::testVarStatic["s"] = 1;
 		let self::testVarStatic["a"]["b"]["c"]["d"]["e"] = "f";
 		let self::testVarStatic[1][2][5] = 6;

--- a/unit-tests/Extension/AssignTest.php
+++ b/unit-tests/Extension/AssignTest.php
@@ -32,7 +32,7 @@ class AssignTest extends \PHPUnit_Framework_TestCase
             "s" => 1
         );
     }
-    
+
     public function testAssign()
     {
         $t = new \Test\Assign();
@@ -94,6 +94,7 @@ class AssignTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($t->testArrayVarAssign2('test_index', 'value') == array('test_index' => 'value'));
         $this->assertTrue($t->testPropertyArray14() == $this->getComplexArrayTestValue());
         $this->assertTrue($t->testStaticPropertyArrayMulti4() == $this->getComplexArrayTestValue());
+        $this->assertTrue($t->testStaticPropertyArrayAppend() == array("test", 1, 1.5, false, array()));
     }
 
     public function testGlobalVarAssign()


### PR DESCRIPTION
Implemented appending array-elements on static properties like

```
let self::abc[] = "test";
```

since multi-level appends like

```
let self::abc["a"][] = "test";
```

were already supported.
