### PR TITLE
Add array_fill to read-only methods to fix segmentation fault

### DIFF
--- a/Library/FunctionCall.php
+++ b/Library/FunctionCall.php
@@ -100,6 +100,7 @@ class FunctionCall extends Call
         switch ($funcName) {
             case 'min':
             case 'max':
+            case 'array_fill':
             case 'call_user_func':
             case 'call_user_func_array':
                 return false;

--- a/test/fcall.zep
+++ b/test/fcall.zep
@@ -99,4 +99,12 @@ class Fcall
 	{
 		return func_get_args();
 	}
+
+	public function testArrayFill()
+	{
+		var v1, v2;
+		let v1 = array_fill(0, 5, "?");
+		let v2 = array_fill(0, 6, "?");
+		return [v1, v2];
+	}
 }

--- a/unit-tests/Extension/FcallTest.php
+++ b/unit-tests/Extension/FcallTest.php
@@ -44,4 +44,10 @@ class FcallTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($t->testFunctionGetArgs(false, 1234) === array(false, 1234));
         $this->assertTrue($t->testFunctionGetArgs(array(1, 2, 3), false) === array(array(1, 2, 3), false));
     }
+
+    public function testArrayFill()
+    {
+        $t = new \Test\Fcall();
+        $this->assertTrue($t->testArrayFill() == array(array_fill(0, 5, "?"), array_fill(0, 6, "?")));
+    }
 }


### PR DESCRIPTION
Fix the problem mentioned in #618.
