### PR TITLE
[BUG] empty operator bug with string "0"

### DIFF
--- a/test/emptytest.zep
+++ b/test/emptytest.zep
@@ -41,4 +41,9 @@ class EmptyTest
 
 		return empty(a);
 	}
+
+        public function testString(string a)
+        {
+                return empty(a);
+        }
 }

--- a/unit-tests/Extension/EmptyTest.php
+++ b/unit-tests/Extension/EmptyTest.php
@@ -25,9 +25,12 @@ class EmptyTest extends \PHPUnit_Framework_TestCase
     {
         $t = new \Test\EmptyTest();
 
-        assert($t->testDynamicVarArrayEmpty() == true);
-        assert($t->testDynamicVarArrayNotEmpty() == false);
-        assert($t->testEmptyString() == true);
-        assert($t->testNotEmptyString() == false);
+        $this->assertTrue($t->testDynamicVarArrayEmpty());
+        $this->assertFalse($t->testDynamicVarArrayNotEmpty());
+        $this->assertTrue($t->testEmptyString());
+        $this->assertFalse($t->testNotEmptyString());
+        $this->assertTrue($t->testString(""));
+        $this->assertFalse($t->testString('this is a string'));
+        $this->assertFalse($t->testString('0'));
     }
 }


### PR DESCRIPTION
Add unit test on empty test for string "0"

The PR does not fix the problem but unit test it
