### PR TITLE
Remove duplicate check for array parameters type in ClassMethod

### DIFF
--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -1010,14 +1010,11 @@ class ClassMethod
                 return $code;
 
             case 'array':
-                $code  = "\tif (unlikely(Z_TYPE_P(" . $parameter['name'] . '_param) != IS_' . strtoupper($dataType) . ')) {' . PHP_EOL;
-                $code .= "\t\t" . 'zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter \'' . $parameter['name'] . '\' must be an ' . $dataType . '") TSRMLS_CC);' . PHP_EOL;
-                $code .= "\t\t" . 'RETURN_MM_NULL();' . PHP_EOL;
-                $code .= "\t" . '}' . PHP_EOL;
-                $code .= PHP_EOL;
-                $code .= "\t\t" . $parameter['name'] . ' = ' . $parameter['name'] . '_param;' . PHP_EOL;
-                $code .= PHP_EOL;
-                return $code;
+                /**
+                 * We dont need to check array type
+                 * because It's already checked with ZEND_ARG_ARRAY_INFO
+                 */
+                break;
 
             case 'object':
             case 'resource':

--- a/ext/php_test.h
+++ b/ext/php_test.h
@@ -14,7 +14,7 @@
 #define PHP_TEST_VERSION     "1.0.0"
 #define PHP_TEST_EXTNAME     "test"
 #define PHP_TEST_AUTHOR      "Zephir Team and contributors"
-#define PHP_TEST_ZEPVERSION  "0.5.8a"
+#define PHP_TEST_ZEPVERSION  "0.5.9a"
 #define PHP_TEST_DESCRIPTION "Description test for<br/>Test Extension"
 
 typedef struct _zephir_struct_test { 

--- a/ext/test/assign.zep.c
+++ b/ext/test/assign.zep.c
@@ -1657,8 +1657,8 @@ PHP_METHOD(Test_Assign, testConstantKeyAssign) {
 	ZEPHIR_INIT_VAR(elements);
 	array_init_size(elements, 5);
 	add_assoc_long_ex(elements, SS("abc"), 1);
-	add_index_long(elements, 14, 7);
-	add_index_long(elements, 15, 8);
+	add_index_long(elements, 131072, 131079);
+	add_index_long(elements, 131073, 131080);
 	ZEPHIR_MM_RESTORE();
 
 }

--- a/ext/test/oo/ooparams.zep.c
+++ b/ext/test/oo/ooparams.zep.c
@@ -217,13 +217,6 @@ PHP_METHOD(Test_Oo_OoParams, setStrictList) {
 
 	zephir_fetch_params(0, 1, 0, &someList_param);
 
-	if (unlikely(Z_TYPE_P(someList_param) != IS_ARRAY)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'someList' must be an array") TSRMLS_CC);
-		RETURN_NULL();
-	}
-
-		someList = someList_param;
-
 
 
 	RETURN_CTORW(someList);


### PR DESCRIPTION
PHP is an awful language in some places

We controll array type by ARG macros

``` php
function test(array $a) {
return $a;
}
test(1);
```

Catchable fatal error: Argument 1 passed to test() must be of the type array, integer given

I dont know how to test array type...

I remove our manual type check because It's already checked
