### PR TITLE
When assigning a value to a superglobal, check for zval separation

### DIFF
--- a/test/assign.zep
+++ b/test/assign.zep
@@ -817,4 +817,17 @@ class Assign
 		var elements;
 		let elements = ["abc": 1, ABDAY_1: DAY_1, ABDAY_2: DAY_2];
 	}
+
+	/**
+	 * @link https://github.com/phalcon/zephir/issues/725
+	 */
+	public function testAssignSuperGlobals()
+	{
+		var v = "stest2";
+		let _GET["steststr"] = "stest";
+		let _GET["steststr2"] = v;
+		let _GET["stestint"] = 1;
+		let _GET["stestint2"] = 2;
+		let _GET[v] = "testval";
+	}
 }

--- a/unit-tests/Extension/AssignTest.php
+++ b/unit-tests/Extension/AssignTest.php
@@ -107,5 +107,13 @@ class AssignTest extends \PHPUnit_Framework_TestCase
         assert(!isset($_POST['test_index']));
         $t->testGlobalVarAssign('test_index', 'value');
         assert($_POST['test_index'] == 'value');
+        
+        /* Check primitive types */
+        $t->testAssignSuperGlobals();
+        assert($_GET["steststr"] == "stest");
+        assert($_GET["steststr2"] == "stest2");
+        assert($_GET["stestint"] == 1);
+        assert($_GET["stestint2"] == 2);
+        assert($_GET["stest2"] == "testval");
     }
 }


### PR DESCRIPTION
This hopefully addresses the issue demonstrated in #725.

Not sure if that's the correct way to fix this, but it seemed relatively safe.