### PR TITLE
Fix function cache for static methods

### DIFF
--- a/ext/kernel/fcall.c
+++ b/ext/kernel/fcall.c
@@ -410,7 +410,7 @@ int zephir_call_user_function(zval **object_pp, zend_class_entry *obj_ce, zephir
 
 	if (!cache_entry || !*cache_entry) {
 		if (zephir_globals_ptr->cache_enabled) {
-			fcall_key_hash = zephir_make_fcall_key(&fcall_key, &fcall_key_len, (object_pp ? Z_OBJCE_PP(object_pp) : obj_ce), type, function_name TSRMLS_CC);
+			fcall_key_hash = zephir_make_fcall_key(&fcall_key, &fcall_key_len, (object_pp && type != zephir_fcall_ce ? Z_OBJCE_PP(object_pp) : obj_ce), type, function_name TSRMLS_CC);
 		}
 	}
 


### PR DESCRIPTION
Addresses and resolves #721.

A static fucntion call in that case is handled ("transformed" by the compiler) as zephir_fcall_ce.
(ce = class entry, which already suggests that we have no object scope)
The current code still passes object_pp (which is an object scope), insteadof the class entry,
as the call type would suggest.

I'm not sure if there are similar issues, with different call types.


