### PR TITLE
Fix the not operator, to respect code expressions

### DIFF
--- a/Library/Operators/Unary/NotOperator.php
+++ b/Library/Operators/Unary/NotOperator.php
@@ -51,7 +51,7 @@ class NotOperator extends BaseOperator
             case 'uint':
             case 'long':
             case 'ulong':
-                return new CompiledExpression('bool', '!' . $left->getCode(), $expression);
+                return new CompiledExpression('bool', '!(' . $left->getCode() . ')', $expression);
 
             case 'variable':
                 $variable = $compilationContext->symbolTable->getVariableForRead($left->getCode(), $compilationContext, $expression['left']);


### PR DESCRIPTION
Code like
```
!Z_TYPE_P(
    (_array ? ZEPHIR_GLOBAL(global_true) : ZEPHIR_GLOBAL(global_false))
) == IS_ARRAY
```
could be produced before.

The problem is, that the not operator (!) has a higher precedence than the assignment operator (=),
which leads to a boolean being compared with IS_ARRAY.
This fixes #680.