### PR TITLE
fcache: Only store cache entries, if they are initialized.

### DIFF
--- a/ext/kernel/fcall.c
+++ b/ext/kernel/fcall.c
@@ -488,7 +488,7 @@ int zephir_call_user_function(zval **object_pp, zend_class_entry *obj_ce, zephir
 	EG(scope) = old_scope;
 
 	if (!cache_entry || !*cache_entry) {
-		if (EXPECTED(status != FAILURE) && fcall_key && !temp_cache_entry) {
+		if (EXPECTED(status != FAILURE) && fcall_key && !temp_cache_entry && fcic.initialized) {
 #ifndef ZEPHIR_RELEASE
 			zephir_fcall_cache_entry *temp_cache_entry = malloc(sizeof(zephir_fcall_cache_entry));
 			temp_cache_entry->f     = fcic.function_handler;


### PR DESCRIPTION
This should fix #715, 
where somehow some function cache entries are uninitialized and still cached.

This leads to some strange null-pointer dereferences and other similar stuff.
I hope the explanation in the commit itself is detailed enough, so I will leave
that summary here that short.