### PR TITLE
Make sure that extended/implemented classes are initialized first

### DIFF
--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -381,6 +381,9 @@ class ClassDefinition
             $classDefinition = $this->extendsClassDefinition;
             if (method_exists($classDefinition, 'increaseDependencyRank')) {
                 $classDefinition->increaseDependencyRank($this->dependencyRank * 2);
+                while ($classDefinition->isInternal() && $classDefinition->getDependencyRank() <= $this->getDependencyRank()) {
+                    $classDefinition->increaseDependencyRank();
+                }
             }
         }
 
@@ -388,6 +391,9 @@ class ClassDefinition
             foreach ($this->implementedInterfaceDefinitions as $interfaceDefinition) {
                 if (method_exists($interfaceDefinition, 'increaseDependencyRank')) {
                     $interfaceDefinition->increaseDependencyRank($this->dependencyRank * 2);
+                    while ($interfaceDefinition->isInternal() && $interfaceDefinition->getDependencyRank() <= $this->getDependencyRank()) {
+                        $interfaceDefinition->increaseDependencyRank();
+                    }
                 }
             }
         }

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -1571,6 +1571,7 @@ class Compiler
         /**
          * Round 1.5 Make a second pass to ensure classes will have the correct weight
          */
+        $files = array_reverse($files);
         foreach ($files as $file) {
             if (!$file->isExternal()) {
                 $classDefinition = $file->getClassDefinition();
@@ -1579,6 +1580,7 @@ class Compiler
                 }
             }
         }
+        $files = array_reverse($files);
 
         $classEntries = array();
         $classInits = array();


### PR DESCRIPTION
This addresses #702.

Currently it's possible that extended/implemented class have the same 
depedency rank, which can lead to the extending class to be initialized
first, where an error occurs becurs the extended class does not exist yet.

I'm not quite sure if that's the best way to do it, so I'm open to feedback.