### PR TITLE
Use the current array, not the fetched one when updating properties

### DIFF
--- a/ext/kernel/array.c
+++ b/ext/kernel/array.c
@@ -1305,7 +1305,8 @@ int zephir_array_update_multi(zval **arr, zval **value TSRMLS_DC, const char *ty
 				if (zephir_array_isset_string_fetch(&fetched, p, s, l + 1, 0 TSRMLS_CC)) {
 					if (Z_TYPE_P(fetched) == IS_ARRAY) {
 						if (i == (types_length - 1)) {
-							zephir_array_update_string(&fetched, s, l, value, PH_COPY | PH_SEPARATE);
+							re_update = Z_REFCOUNT_P(p) > 1 && !Z_ISREF_P(p);
+							zephir_array_update_string(&p, s, l, value, PH_COPY | PH_SEPARATE);
 						} else {
 							p = fetched;
 						}
@@ -1337,7 +1338,8 @@ int zephir_array_update_multi(zval **arr, zval **value TSRMLS_DC, const char *ty
 				if (zephir_array_isset_long_fetch(&fetched, p, ll, 0 TSRMLS_CC)) {
 					if (Z_TYPE_P(fetched) == IS_ARRAY) {
 						if (i == (types_length - 1)) {
-							zephir_array_update_long(&fetched, ll, value, PH_COPY | PH_SEPARATE ZEPHIR_DEBUG_PARAMS_DUMMY);
+							re_update = Z_REFCOUNT_P(p) > 1 && !Z_ISREF_P(p);
+							zephir_array_update_long(&p, ll, value, PH_COPY | PH_SEPARATE ZEPHIR_DEBUG_PARAMS_DUMMY);
 						} else {
 							p = fetched;
 						}
@@ -1369,7 +1371,8 @@ int zephir_array_update_multi(zval **arr, zval **value TSRMLS_DC, const char *ty
 				if (zephir_array_isset_fetch(&fetched, p, item, 0 TSRMLS_CC)) {
 					if (Z_TYPE_P(fetched) == IS_ARRAY) {
 						if (i == (types_length - 1)) {
-							zephir_array_update_zval(&fetched, item, value, PH_COPY | PH_SEPARATE);
+							re_update = Z_REFCOUNT_P(p) > 1 && !Z_ISREF_P(p);
+							zephir_array_update_zval(&p, item, value, PH_COPY | PH_SEPARATE);
 						} else {
 							p = fetched;
 						}

--- a/ext/kernel/object.c
+++ b/ext/kernel/object.c
@@ -1068,7 +1068,8 @@ int zephir_update_property_array_multi(zval *object, const char *property, zend_
 					if (zephir_array_isset_string_fetch(&fetched, p, s, l + 1, 0 TSRMLS_CC)) {
 						if (Z_TYPE_P(fetched) == IS_ARRAY) {
 							if (i == (types_length - 1)) {
-								zephir_array_update_string(&fetched, s, l, value, PH_COPY | PH_SEPARATE);
+								re_update = Z_REFCOUNT_P(p) > 1 && !Z_ISREF_P(p);
+								zephir_array_update_string(&p, s, l, value, PH_COPY | PH_SEPARATE);
 							} else {
 								p = fetched;
 							}
@@ -1100,7 +1101,8 @@ int zephir_update_property_array_multi(zval *object, const char *property, zend_
 					if (zephir_array_isset_long_fetch(&fetched, p, ll, 0 TSRMLS_CC)) {
 						if (Z_TYPE_P(fetched) == IS_ARRAY) {
 							if (i == (types_length - 1)) {
-								zephir_array_update_long(&fetched, ll, value, PH_COPY | PH_SEPARATE ZEPHIR_DEBUG_PARAMS_DUMMY);
+								re_update = Z_REFCOUNT_P(p) > 1 && !Z_ISREF_P(p);
+								zephir_array_update_long(&p, ll, value, PH_COPY | PH_SEPARATE ZEPHIR_DEBUG_PARAMS_DUMMY);
 							} else {
 								p = fetched;
 							}
@@ -1132,7 +1134,8 @@ int zephir_update_property_array_multi(zval *object, const char *property, zend_
 					if (zephir_array_isset_fetch(&fetched, p, item, 0 TSRMLS_CC)) {
 						if (Z_TYPE_P(fetched) == IS_ARRAY) {
 							if (i == (types_length - 1)) {
-								zephir_array_update_zval(&fetched, item, value, PH_COPY | PH_SEPARATE);
+								re_update = Z_REFCOUNT_P(p) > 1 && !Z_ISREF_P(p);
+								zephir_array_update_zval(&p, item, value, PH_COPY | PH_SEPARATE);
 							} else {
 								p = fetched;
 							}

--- a/test/nativearray.zep
+++ b/test/nativearray.zep
@@ -602,4 +602,24 @@ class NativeArray
 	{
 	    return !isset(tokens[1]);
 	}
+
+	public function issue743a(array current)
+	{
+		let current[42]["str"] = "ok";
+		return current;
+	}
+
+	public function issue743b(array current)
+	{
+		let current["str"][42] = "ok";
+		return current;
+	}
+
+	public function issue743c(array current)
+	{
+		var key;
+		let key = "hey";
+		let current["str"][$key] = "ok";
+		return current;
+	}
 }

--- a/unit-tests/Extension/NativeArrayTest.php
+++ b/unit-tests/Extension/NativeArrayTest.php
@@ -122,4 +122,42 @@ class NativeArrayTest extends \PHPUnit_Framework_TestCase
         $t = new NativeArray();
         $this->assertFalse($t->issue264(array(1, 2, 3)));
     }
+
+    public function testIssue743()
+    {
+        $t = new NativeArray();
+
+        $expected = array(42 => array("str" => "ok"));
+        $this->assertEquals($expected, $t->issue743a(array(42 => array())));
+        $this->assertEquals($expected, $t->issue743a(array(42 => array("str" => null))));
+        $this->assertEquals($expected, $t->issue743a(array(42 => array("str" => 42.7))));
+        $this->assertEquals($expected, $t->issue743a(array(42 => array("str" => 42))));
+        $this->assertEquals($expected, $t->issue743a(array(42 => array("str" => true))));
+        $this->assertEquals($expected, $t->issue743a(array(42 => array("str" => "bad"))));
+        $this->assertEquals($expected, $t->issue743a(array(42 => array("str" => array()))));
+        $this->assertEquals($expected, $t->issue743a(array(42 => array("str" => array("hey")))));
+        $this->assertEquals($expected, $t->issue743a(array(42 => array("str" => new \stdClass()))));
+
+        $expected = array("str" => array(42 => "ok"));
+        $this->assertEquals($expected, $t->issue743b(array("str" => array())));
+        $this->assertEquals($expected, $t->issue743b(array("str" => array(42 => null))));
+        $this->assertEquals($expected, $t->issue743b(array("str" => array(42 => 42.7))));
+        $this->assertEquals($expected, $t->issue743b(array("str" => array(42 => 42))));
+        $this->assertEquals($expected, $t->issue743b(array("str" => array(42 => true))));
+        $this->assertEquals($expected, $t->issue743b(array("str" => array(42 => "bad"))));
+        $this->assertEquals($expected, $t->issue743b(array("str" => array(42 => array()))));
+        $this->assertEquals($expected, $t->issue743b(array("str" => array(42 => array("hey")))));
+        $this->assertEquals($expected, $t->issue743b(array("str" => array(42 => new \stdClass()))));
+
+        $expected = array("str" => array("hey" => "ok"));
+        $this->assertEquals($expected, $t->issue743c(array("str" => array())));
+        $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => null))));
+        $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => 42.7))));
+        $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => 42))));
+        $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => true))));
+        $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => "bad"))));
+        $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => array()))));
+        $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => array("hey")))));
+        $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => new \stdClass()))));
+    }
 }


### PR DESCRIPTION
Issue #743 