### PR TITLE
Fix DivOperator to be thread-safe by adding missing TSRMLS_CC

### DIFF
--- a/Library/Operators/Arithmetical/DivOperator.php
+++ b/Library/Operators/Arithmetical/DivOperator.php
@@ -143,7 +143,7 @@ class DivOperator extends ArithmeticalBaseOperator
                     case 'uint':
                     case 'long':
                     case 'ulong':
-                        return new CompiledExpression('double', 'zephir_safe_div_double_long(' . $left->getCode() . ', (double) (' . $right->getCode() . '))', $expression);
+                        return new CompiledExpression('double', 'zephir_safe_div_double_long(' . $left->getCode() . ', (double) (' . $right->getCode() . ') TSRMLS_CC)', $expression);
 
                     case 'double':
                         return new CompiledExpression('double', 'zephir_safe_div_double_long(' . $left->getCode() . ', ' . $right->getCode() . ' TSRMLS_CC)', $expression);


### PR DESCRIPTION
Trivial fix, to allow compiling as ZTS, when using the div operator.
