### PR TITLE
Array Assign: Fix reference copy to protect the source from the GC

### DIFF
--- a/ext/kernel/memory.h
+++ b/ext/kernel/memory.h
@@ -160,6 +160,7 @@ void zephir_deinitialize_memory(TSRMLS_D);
 	}
 
 #define ZEPHIR_CPY_WRT(d, v) \
+	Z_ADDREF_P(v); \
 	if (d) { \
 		if (Z_REFCOUNT_P(d) > 0) { \
 			zephir_ptr_dtor(&d); \
@@ -167,7 +168,6 @@ void zephir_deinitialize_memory(TSRMLS_D);
 	} else { \
 		zephir_memory_observe(&d TSRMLS_CC); \
 	} \
-	Z_ADDREF_P(v); \
 	d = v;
 
 #define ZEPHIR_CPY_WRT_CTOR(d, v) \

--- a/test/nativearray.zep
+++ b/test/nativearray.zep
@@ -622,4 +622,22 @@ class NativeArray
 		let current["str"][$key] = "ok";
 		return current;
 	}
+
+	/**
+	 * @link https://github.com/phalcon/zephir/issues/709
+	 */
+	public function issue709()
+	{
+		var c, arr;
+		var works = true;
+
+		for c in range(0, 50) {
+			let arr = [1, 2];
+			let arr = arr[array_rand(arr)];
+			if arr < 0 || arr > 2 {
+				let works = false;
+			}
+		}
+		return works;
+	}
 }

--- a/unit-tests/Extension/NativeArrayTest.php
+++ b/unit-tests/Extension/NativeArrayTest.php
@@ -160,4 +160,10 @@ class NativeArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => array("hey")))));
         $this->assertEquals($expected, $t->issue743c(array("str" => array("hey" => new \stdClass()))));
     }
+    
+    public function testIssue709()
+    {
+        $t = new NativeArray();
+        $this->assertTrue($t->Issue709());
+    }
 }


### PR DESCRIPTION
Fixes #709.

The problem is that it's possible that the garbage collector frees the data which should be copied.

Problem analysis:
```
zephir_array_fetch(&_1, arr, _2, PH_NOISY | PH_READONLY, "xxx", 59 TSRMLS_CC);
ZEPHIR_CPY_WRT(arr, _1);
```
The problem is that _1 is potentially a pointer to an element of arr 
and ZEPHIR_CPY_WRT does add the reference AFTER calling
the Destructor (which may lead to garbage collector activity
and therefore to an "use-after-free" bug.)

