### PR TITLE
Allow build on PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/phalcon/zephir/issues?state=open"
     },
     "require": {
-        "php": "~5.3",
+        "php": ">=5.3",
         "ext-json": "*",
         "ext-hash": "*",
         "ext-ctype": "*"


### PR DESCRIPTION
When I'm trying to build with travis on PHP 7:
> phalcon/zephir dev-master requires php ~5.3 -> your PHP version does not satisfy that requirement.