### PR TITLE
Fix ExitDieTest to use the PHP binary of zephir (which runs phpunit)

### DIFF
--- a/unit-tests/Extension/ExitDieTest.php
+++ b/unit-tests/Extension/ExitDieTest.php
@@ -23,21 +23,27 @@ class ExitDieTest extends \PHPUnit_Framework_TestCase
 {
     public function testExitDie()
     {
+        /* Only available since PHP 5.4*/
+        if (defined('PHP_BINARY')) {
+            $phpBinary = constant('PHP_BINARY');
+        } else {
+            $phpBinary = PHP_BINDIR . DIRECTORY_SEPARATOR . 'php';
+        }
         $testfile1 = __DIR__ .'/fixtures/exit.php';
-        $return1 = `php $testfile1`;
+        $return1 = `$phpBinary $testfile1`;
         $this->assertEquals("", trim($return1));
 
 
         $arg = "Hello World";
         $testfile2 = __DIR__ .'/fixtures/exit_string.php';
-        $return2 = `php $testfile2 "$arg"`;
+        $return2 = `$phpBinary $testfile2 "$arg"`;
         $this->assertEquals($arg, trim($return2));
 
 
         $testfile3 = __DIR__ .'/fixtures/exit_int.php';
         $int_arg = 128;
-        $return3 = `php $testfile3 $int_arg || echo "$?"`;
-        $return3 = intval(trim($return3));
+        $cmd3 = "$phpBinary $testfile3 $int_arg";
+        exec($cmd3, $out3, $return3);
         $this->assertTrue($return3 == $int_arg);
     }
 }


### PR DESCRIPTION
This then also allows all tests to pass on Win32,
when using a non-debug build.

This also generally allows to have another PHP binary in path
than the one using zephir.