### PR TITLE
Fix ZTS for time and more work on optimizers (Substr, Round)

### DIFF
--- a/Library/Optimizers/FunctionCall/IsIntOptimizer.php
+++ b/Library/Optimizers/FunctionCall/IsIntOptimizer.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2015 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Zephir\Optimizers\FunctionCall;
+
+use Zephir\Optimizers\IsTypeOptimizerAbstract;
+
+/**
+ * IsIntOptimizer
+ *
+ * Optimizes calls to 'is_int' using internal function
+ */
+class IsIntOptimizer extends IsTypeOptimizerAbstract
+{
+    protected function getType()
+    {
+        return 'IS_LONG';
+    }
+}

--- a/Library/Optimizers/FunctionCall/MicrotimeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/MicrotimeOptimizer.php
@@ -65,11 +65,11 @@ class MicrotimeOptimizer extends OptimizerAbstract
 
         if (!isset($expression['parameters'])) {
             $symbolVariable->setDynamicTypes('string');
-            $context->codePrinter->output('zephir_microtime(' . $symbolVariable->getName() . ', NULL);');
+            $context->codePrinter->output('zephir_microtime(' . $symbolVariable->getName() . ', NULL TSRMLS_CC);');
         } else {
             $symbolVariable->setDynamicTypes('double');
             $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
-            $context->codePrinter->output('zephir_microtime(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ');');
+            $context->codePrinter->output('zephir_microtime(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         }
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/RoundOptimizer.php
+++ b/Library/Optimizers/FunctionCall/RoundOptimizer.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2015 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Zephir\Optimizers\FunctionCall;
+
+use Zephir\Call;
+use Zephir\CompilationContext;
+use Zephir\CompilerException;
+use Zephir\CompiledExpression;
+use Zephir\Optimizers\OptimizerAbstract;
+
+/**
+ * RoundOptimizer
+ *
+ * Optimizes calls to 'round' using internal function
+ * parameters float $val [, int $precision = 0 [, int $mode = PHP_ROUND_HALF_UP ]]
+ */
+class RoundOptimizer extends OptimizerAbstract
+{
+    /**
+     * @param array $expression
+     * @param Call $call
+     * @param CompilationContext $context
+     * @return bool|CompiledExpression|mixed
+     * @throws CompilerException
+     */
+    public function optimize(array $expression, Call $call, CompilationContext $context)
+    {
+        if (!isset($expression['parameters'])) {
+            return false;
+        }
+
+        if (count($expression['parameters']) > 4) {
+            return false;
+        }
+
+        /**
+         * Process the expected symbol to be returned
+         */
+        $call->processExpectedReturn($context);
+
+        $symbolVariable = $call->getSymbolVariable(true, $context);
+        if ($symbolVariable->isNotVariableAndString()) {
+            throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
+        }
+
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
+
+        $context->headersManager->add('kernel/operators');
+        $symbolVariable->setDynamicTypes('double');
+
+        $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        
+        if (count($expression['parameters']) == 1) { //Only float $val
+            $context->codePrinter->output('zephir_round(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', NULL, NULL TSRMLS_CC);');
+        } else if (count($expression['parameters']) == 2) { //float $val, int $mode
+            $context->codePrinter->output('zephir_round(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ', NULL TSRMLS_CC);');
+        } else { //all
+            $context->codePrinter->output('zephir_round(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ', ' . $resolvedParams[2] . ' TSRMLS_CC);');
+        }
+        return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
+    }
+}

--- a/ext/kernel/object.h
+++ b/ext/kernel/object.h
@@ -147,12 +147,12 @@ ZEPHIR_ATTR_NONNULL static inline zval* zephir_fetch_nproperty_this_quick(zval *
 {
 #ifdef __GNUC__
   if (__builtin_constant_p(property_name) && __builtin_constant_p(property_length)) {
-	zval *result = zephir_fetch_property_this_quick(object, property_name, property_length, zend_inline_hash_func(property_name, property_length + 1), silent TSRMLS_CC);
+	zval *result = zephir_fetch_property_this_quick(object, property_name, property_length, key, silent TSRMLS_CC);
 	return result ? result : EG(uninitialized_zval_ptr);
   }
 #endif
 
-  zval *result = zephir_fetch_property_this_quick(object, property_name, property_length, zend_hash_func(property_name, property_length + 1), silent TSRMLS_CC);
+  zval *result = zephir_fetch_property_this_quick(object, property_name, property_length, key, silent TSRMLS_CC);
   return result ? result : EG(uninitialized_zval_ptr);
 }
 

--- a/ext/kernel/operators.h
+++ b/ext/kernel/operators.h
@@ -154,6 +154,7 @@ double zephir_safe_div_double_zval(double op1, zval *op2 TSRMLS_DC);
 
 void zephir_floor(zval *return_value, zval *op1 TSRMLS_DC);
 void zephir_ceil(zval *return_value, zval *op1 TSRMLS_DC);
+void zephir_round(zval *return_value, zval *op1, zval *op2, zval *op3 TSRMLS_DC);
 void zephir_pow(zval *return_value, zval *op1, zval *op2 TSRMLS_DC);
 
 #define zephir_get_numberval(z) (Z_TYPE_P(z) == IS_LONG ? Z_LVAL_P(z) : zephir_get_doubleval(z))

--- a/ext/kernel/string.h
+++ b/ext/kernel/string.h
@@ -26,6 +26,7 @@
 #define ZEPHIR_TRIM_LEFT  1
 #define ZEPHIR_TRIM_RIGHT 2
 #define ZEPHIR_TRIM_BOTH  3
+#define ZEPHIR_SUBSTR_NO_LENGTH 1
 
 /** Fast char position */
 int zephir_memnstr(const zval *haystack, const zval *needle ZEPHIR_DEBUG_PARAMS);
@@ -72,7 +73,7 @@ void zephir_unique_key(zval *return_value, zval *prefix, zval *value TSRMLS_DC);
 int zephir_spprintf(char **message, int max_len, char *format, ...);
 
 /* Substr */
-void zephir_substr(zval *return_value, zval *str, long from, long length);
+void zephir_substr(zval *return_value, zval *str, long from, long length, int flags);
 
 /** EOL */
 zval *zephir_eol(int eol TSRMLS_DC);

--- a/ext/kernel/time.c
+++ b/ext/kernel/time.c
@@ -41,7 +41,7 @@ void zephir_time(zval *return_value)
 	RETURN_LONG(time(NULL));
 }
 
-void zephir_microtime(zval *return_value, zval *get_as_float)
+void zephir_microtime(zval *return_value, zval *get_as_float TSRMLS_DC)
 {
 	struct timeval tp = {0};
 	char ret[100];

--- a/ext/kernel/time.h
+++ b/ext/kernel/time.h
@@ -21,7 +21,7 @@
 
 void zephir_time(zval *return_value);
 #ifdef HAVE_GETTIMEOFDAY
-void zephir_microtime(zval *return_value, zval *get_as_float);
+void zephir_microtime(zval *return_value, zval *get_as_float TSRMLS_DC);
 #endif
 
 #endif /* ZEPHIR_KERNEL_TIME_H */

--- a/test/optimizers/substr.zep
+++ b/test/optimizers/substr.zep
@@ -1,0 +1,15 @@
+
+namespace Test\Optimizers;
+
+class Substr
+{
+	public function testTwoArguments(var str, var start)
+	{
+		return substr(str, start);
+	}
+	
+	public function testThreeArguments(var str, var start, var offset)
+	{
+		return substr(str, start, offset);
+	}
+}

--- a/unit-tests/Extension/Optimizers/SubstrTest.php
+++ b/unit-tests/Extension/Optimizers/SubstrTest.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2015 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Extension\Optimizers;
+
+use Test\Optimizers\Substr;
+
+class SubstrTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTwoArguments1()
+    {
+        $t = new Substr();
+        
+        $strings_array = array(null, '', 12345, 'abcdef', '123abc', '_123abc');
+        $results1 = array(false, false, '2345', 'bcdef', '23abc', '123abc');
+        $results2 = array(false, false, '12345', 'abcdef', '123abc', '_123abc');
+        $results3 = array(false, false, '45', 'ef', 'bc', 'bc');
+        
+        $c = 0;
+        foreach ($strings_array as $str) {
+            echo $str."\n";
+            $this->assertSame($t->testTwoArguments($str, 1), $results1[$c]);
+            $this->assertSame($t->testTwoArguments($str, 0), $results2[$c]);
+            $this->assertSame($t->testTwoArguments($str, -2), $results3[$c]);
+            ++$c;
+        }
+    }
+    
+    public function testThreeArguments1()
+    {
+        $t = new Substr();
+        $this->assertSame($t->testThreeArguments('abcdef', 0, -3), 'abc');
+        $this->assertSame($t->testThreeArguments('123abc', 0, 3), '123');
+        $this->assertSame($t->testThreeArguments('abcdef', 1, -3), 'bc');
+        $this->assertSame($t->testThreeArguments('abcdef', -2, 0), '');
+        $this->assertSame($t->testThreeArguments(12345, 1, -1), '234');
+    }
+}


### PR DESCRIPTION
Fixed the ZTS issue with the **microtime optimizer**, which caused the travis failure.
(Unfortunately I didn't think of that issue, so it sneaked into my PR...)

Fixed the **substr optimizer** and added some of PHP's own unit tests for it.
Implemented a round optimizer.

Added an optimizer for **is_int** and made 
**zephir_fetch_nproperty_this_quick** use the passed hash
instead of calculating one again.
