### PR TITLE
Fix boolean variable comparision to use appropriate zval operator

### DIFF
--- a/Library/Operators/Comparison/ComparisonBaseOperator.php
+++ b/Library/Operators/Comparison/ComparisonBaseOperator.php
@@ -401,8 +401,8 @@ class ComparisonBaseOperator extends BaseOperator
 
                             case 'variable':
                                 $compilationContext->headersManager->add('kernel/operators');
-                                return new CompiledExpression('bool', 'ZEPHIR_IS_BOOL(' . $variableRight->getName() . ', ' . $left->getBooleanCode() . ')', $expression);
-
+                                $boolOperator = $left->getBooleanCode() == '1' ? $this->_zvalBoolTrueOperator : $this->_zvalBoolFalseOperator;
+                                return new CompiledExpression('bool', $boolOperator . '(' . $variableRight->getName() . ')', $expression);
                             default:
                                 throw new CompilerException("Unknown type: " . $variableRight->getType(), $expression['right']);
                         }

--- a/test/operator.zep
+++ b/test/operator.zep
@@ -2,8 +2,18 @@ namespace Test;
 
 class Operator
 {
-    public function testIdentical(param1, param2)
-    {
-        return param1 === param2;
-    }
+	public function testIdentical(param1, param2)
+	{
+		return param1 === param2;
+	}
+
+	public function testIdenticalVarFalse(param)
+	{
+		return param === FALSE;
+	}
+
+	public function testIdenticalFalseVar(param)
+	{
+		return FALSE === param;
+	}
 }

--- a/unit-tests/Extension/OperatorTest.php
+++ b/unit-tests/Extension/OperatorTest.php
@@ -33,4 +33,16 @@ class OperatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($t->testIdentical(true, true));
         $this->assertTrue($t->testIdentical('phalcon', 'phalcon'));
     }
+    
+    public function test829Issue()
+    {
+        $t = new \Test\Operator();
+        
+        $this->assertTrue($t->testIdenticalVarFalse(false));
+        $this->assertFalse($t->testIdenticalVarFalse(0));
+        $this->assertFalse($t->testIdenticalVarFalse(''));
+        $this->assertTrue($t->testIdenticalFalseVar(false));
+        $this->assertFalse($t->testIdenticalFalseVar(0));
+        $this->assertFalse($t->testIdenticalFalseVar(''));
+    }
 }


### PR DESCRIPTION
Fixes #829

(Also replaced spaces in operator.zep by tabs)