### PR TITLE
Fix travis build: re2c exception

### DIFF
--- a/parser/scanner.re
+++ b/parser/scanner.re
@@ -546,7 +546,7 @@ int xx_get_token(xx_scanner_state *s, xx_scanner_token *token) {
 			return 0;
 		}
 
-		// We have to remove this and define constants in compiler
+		/* We have to remove this and define constants in compiler */
 		IDENTIFIER = [\\_\$]?[_a-zA-Z\\][a-zA-Z0-9_\\]*;
 		IDENTIFIER {
 
@@ -599,7 +599,7 @@ int xx_get_token(xx_scanner_state *s, xx_scanner_token *token) {
 				}
 			}
 
-			// This is hack
+			/* This is hack */
 			if (token->len == 1 && !memcmp(token->value, "_", sizeof("_")-1)
 				|| token->len == 2 && !memcmp(token->value, "__", sizeof("__")-1)
 				|| token->len == 3 && !memcmp(token->value, "___", sizeof("___")-1)


### PR DESCRIPTION
The re2c compilation step fails since c++ comments ``//`` are used.

Replaced them with C-style `/**/` block-comments and now
the parsing seems to work, resulting in a successful travis build.

https://travis-ci.org/steffengy/zephir/builds/56620190