### PR TITLE
Add checks to detect whether a function has been declared multiple times

### DIFF
--- a/Library/FunctionDefinition.php
+++ b/Library/FunctionDefinition.php
@@ -199,6 +199,14 @@ class FunctionDefinition
     {
         return $this->name;
     }
+    
+    /**
+     * Get the internal name used in generated C code
+     */
+    public function getInternalName()
+    {
+        return ($this->isGlobal() ? 'g_' : 'f_') . str_replace('\\', '_', $this->namespace) . '_' . $this->getName();
+    }
 
     public function isGlobal()
     {


### PR DESCRIPTION
Previously it lead to compile-time errors, when a function was (invalidly) declared multiple times.

This still supports multiple function declarations (with the same name) in multiple namespaces.
It detects and fails on:
- multiple global functions with the same name
- multiple namespaced functions, with the same name in the same namespace

The code duplication mentioned in #772 is also removed.