### PR TITLE
Removed a leading underscore from a protected property.

### DIFF
--- a/Library/BranchGraph.php
+++ b/Library/BranchGraph.php
@@ -56,7 +56,7 @@ class BranchGraph
             $branchNode = $parentBranchNode;
             $tempBranch = $tempBranch->getParentBranch();
             if (!$tempBranch) {
-                $this->_root = $parentBranchNode;
+                $this->root = $parentBranchNode;
             }
         }
     }


### PR DESCRIPTION
This was left out of https://github.com/phalcon/zephir/commit/247072464e571b0d6b1ec19bc20c362859fbd125#diff-1