### PR TITLE
Fix win32 build: wrong position of ZEPHIR_FASTCALL at zephir_create_arra...

### DIFF
--- a/ext/kernel/array.c
+++ b/ext/kernel/array.c
@@ -1469,7 +1469,7 @@ int zephir_array_update_multi(zval **arr, zval **value TSRMLS_DC, const char *ty
 	return 0;
 }
 
-ZEPHIR_FASTCALL void zephir_create_array(zval *return_value, uint size, int initialize TSRMLS_DC) {
+void ZEPHIR_FASTCALL zephir_create_array(zval *return_value, uint size, int initialize TSRMLS_DC) {
 
 	uint i;
 	zval *null_value;

--- a/ext/kernel/array.h
+++ b/ext/kernel/array.h
@@ -81,7 +81,7 @@ int zephir_array_is_associative(zval *arr);
 void zephir_array_update_multi_ex(zval **arr, zval **value, const char *types, int types_length, int types_count, va_list ap TSRMLS_DC);
 int zephir_array_update_multi(zval **arr, zval **value TSRMLS_DC, const char *types, int types_length, int types_count, ...);
 
-ZEPHIR_FASTCALL void zephir_create_array(zval *return_value, uint size, int initialize TSRMLS_DC);
+void ZEPHIR_FASTCALL zephir_create_array(zval *return_value, uint size, int initialize TSRMLS_DC);
 
 #define zephir_array_fast_append(arr, value) \
   Z_ADDREF_P(value); \


### PR DESCRIPTION
Trivial change, just a ZEPHIR_FASTCALL at the wrong position, which confuses MSVC