### PR TITLE
Add suport for Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
 
 install:
  - composer --prefer-source install
+ - ./install
 
 before_script:
  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"/usr/local/lib"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To build the PHP extension:
 Installation
 ------------
 You can install zephir using composer.
-Run `composer require phalcon/zephir`, then run `zephir`
+Run `composer require phalcon/zephir`, run `./install` and then run `zephir`
 from your `bin-dir`. By default it is `./vendor/bin/zephir`.
 You can read more about composer binaries
 in it's [documentation](https://getcomposer.org/doc/articles/vendor-binaries.md).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,69 @@
+environment:
+  matrix:
+  - PHP_VERSION: 5.6.7
+    PHP_DEP_VER: 5.6
+  BUILD_PLATFORM: x86
+  PHP_VC: 11
+  PHP_SDK: c:\projects\php-sdk
+  PHP_DEVPACK: c:\projects\php-devpack
+
+cache:
+  - vendor -> composer.json
+
+version: '{build}-$(PHP_VERSION)'
+os: Windows Server 2012
+clone_folder: c:\projects\zephir
+
+matrix:
+  fast_finish: true
+  
+install:
+  - echo Initializing Build...
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - git submodule update --init --recursive
+  - echo Preparing zephir win32 build...
+  - echo Downloading PHP source code [%PHP_VERSION%]
+  - ps: (new-object net.webclient).DownloadFile('http://windows.php.net/downloads/releases/php-' + ${env:PHP_VERSION} + '-Win32-VC' + ${env:PHP_VC} + '-' + ${env:BUILD_PLATFORM} + '.zip', ${env:APPVEYOR_BUILD_FOLDER} + '\..\php.zip')
+  - cd ..
+  - 'mkdir php && mv php.zip php\php.zip && cd php'
+  - 7z.exe x php.zip | FIND /V "ing  "
+  - cd ..
+  - echo Downloading PHP-SDK
+  - mkdir php-sdk && cd php-sdk
+  - ps: (new-object net.webclient).DownloadFile('http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip', ${env:APPVEYOR_BUILD_FOLDER} + '\..\php-sdk.zip')
+  - '7z.exe x ..\php-sdk.zip | FIND /V "ing  "'
+  - cd ..
+  - echo Downloading PHP-Devel-Pack
+  - ps: (new-object net.webclient).DownloadFile('http://windows.php.net/downloads/releases/php-devel-pack-' + ${env:PHP_VERSION} + '-Win32-VC' + ${env:PHP_VC} + '-' + ${env:BUILD_PLATFORM} + '.zip', ${env:APPVEYOR_BUILD_FOLDER} + '\..\php-dev.zip')
+  - 7z.exe x php-dev.zip | FIND /V "ing  "
+  - mv php-%PHP_VERSION%-devel-VC11-%BUILD_PLATFORM% php-devpack
+  - echo Building JSON-C
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - cd json-c
+  - msbuild.exe json-c.sln /t:Build /p:Configuration=Debug;Platform=Win32
+  - echo Building Zephir Parser
+  - 'copy Debug\json-c.lib ..\parser\json-c.lib'
+  - 'cd ..\parser'
+  - 'copy %PHP_SDK%\bin\re2c.exe .\re2c.exe'
+  - buildWin32.bat
+  - echo Building PHP [%PHP_VERSION%]
+  - '"%VS110COMNTOOLS%\VsDevCmd" %BUILD_PLATFORM%'
+  - '%PHP_SDK%\bin\phpsdk_setvars'
+  - 'cd %APPVEYOR_BUILD_FOLDER%\..\php'
+  - 'echo extension_dir=%APPVEYOR_BUILD_FOLDER%\..\php\ext > php.ini'
+  - 'echo extension=%APPVEYOR_BUILD_FOLDER%\ext\Release_TS\php_test.dll >> php.ini'
+  - 'echo extension=php_openssl.dll >> php.ini'
+  - 'echo extension=php_pdo_sqlite.dll >> php.ini'
+  - 'echo extension=php_gmp.dll >> php.ini'
+  - 'set PATH=%cd%;%PATH%'
+  - echo Building Zephir
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - 'copy parser\parser.exe bin\zephir-parser.exe'
+  - if not exist vendor (php -r "readfile('https://getcomposer.org/installer');" | php & php composer.phar --prefer-source install)
+  
+build_script:
+  - 'bin\zephir build'
+  - 'php vendor\phpunit\phpunit\phpunit.php --debug'
+
+artifacts:
+  - path: bin\zephir-parser.exe

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,6 @@
         }
     },
     "bin": ["bin/zephir"],
-    "scripts": {
-        "post-install-cmd": ["./install"],
-        "post-update-cmd": ["./install"]
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"


### PR DESCRIPTION
Example results:
https://ci.appveyor.com/project/steffengy/zephir/build/42-

Also the parser is built and downloadable:
https://ci.appveyor.com/project/steffengy/zephir/build/42-/artifacts

**Possible todos** for integration into into zephir:
- Enable hooks for the real zephir repository.
- Add status badges to README.md
- Configure notifications
- Make sure the latest zephir-parser build is used? (maybe deploy to git/some other location, ...)

refs #817 