### PR TITLE
Preg-match optimizer: Re-enable with fixes

### DIFF
--- a/Library/Optimizers/FunctionCall/PregMatchOptimizer.php
+++ b/Library/Optimizers/FunctionCall/PregMatchOptimizer.php
@@ -46,9 +46,6 @@ class PregMatchOptimizer extends OptimizerAbstract
     public function optimize(array $expression, Call $call, CompilationContext $context)
     {
 
-        /** disabled: this optimizer has bugs or its behavior does not match the same as php */
-        return false;
-
         if (!isset($expression['parameters'])) {
             return false;
         }
@@ -123,7 +120,7 @@ class PregMatchOptimizer extends OptimizerAbstract
             $offset = '0 ';
         }
 
-        $context->codePrinter->output('zephir_preg_match(' . $symbolVariable->getName() . ', &(' . $symbolVariable->getName() . '), ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ', ' . $matchesVariable->getName() . ', ' . $this::GLOBAL_MATCH . ', ' . $flags . ', ' . $offset . ' TSRMLS_CC);');
+        $context->codePrinter->output('zephir_preg_match(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ', ' . $matchesVariable->getName() . ', ' . $this::GLOBAL_MATCH . ', ' . $flags . ', ' . $offset . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }
 }

--- a/ext/kernel/string.c
+++ b/ext/kernel/string.c
@@ -1238,12 +1238,12 @@ void zephir_crc32(zval *return_value, zval *str TSRMLS_DC) {
 	RETVAL_LONG(crc ^ 0xFFFFFFFF);
 }
 
-#if ZEPHIR_USE_PHP_PCRE
+#ifdef ZEPHIR_USE_PHP_PCRE
 
 /**
  * Execute preg-match without function lookup in the PHP userland
  */
-void zephir_preg_match(zval *return_value, zval **return_value_ptr, zval *regex, zval *subject, zval *matches, int global, long flags, long offset TSRMLS_DC) {
+void zephir_preg_match(zval *return_value, zval *regex, zval *subject, zval *matches, int global, long flags, long offset TSRMLS_DC) {
 
 	zval copy;
 	int use_copy = 0;
@@ -1284,28 +1284,36 @@ void zephir_preg_match(zval *return_value, zval **return_value_ptr, zval *regex,
 
 #else
 
-void zephir_preg_match(zval *return_value, zval **return_value_ptr, zval *regex, zval *subject, zval *matches, int global, long flags, long offset TSRMLS_DC)
+void zephir_preg_match(zval *return_value, zval *regex, zval *subject, zval *matches, int global, long flags, long offset TSRMLS_DC)
 {
+	zval tmp_flags;
+	zval tmp_offset;
+	zval *rv = NULL;
+	zval **rvp = &rv;
+
 	if (matches) {
 		Z_SET_ISREF_P(matches);
 	}
+	ZEPHIR_SINIT_VAR(tmp_flags);
+	ZEPHIR_SINIT_VAR(tmp_offset);
+	ZVAL_LONG(&tmp_flags, flags);
+	ZVAL_LONG(&tmp_offset, offset);
 
-	if (global) {
-		if (flags != 0 || offset != 0) {
-			//zephir_call_func_params(return_value, return_value_ptr, SL("preg_match_all") TSRMLS_CC, (matches ? 3 : 2), regex, subject, matches, flags, offset);
+	{
+		zval *tmp_params[5] = { regex, subject, matches, &tmp_flags, &tmp_offset };
+
+		if (global) {
+			zephir_call_func_aparams(rvp, SL("preg_match_all"), NULL, 5, tmp_params TSRMLS_CC);
 		} else {
-			//zephir_call_func_params(return_value, return_value_ptr, SL("preg_match_all") TSRMLS_CC, (matches ? 3 : 2), regex, subject, matches);
-		}
-	} else {
-		if (flags != 0 || offset != 0) {
-			//zephir_call_func_params(return_value, return_value_ptr, SL("preg_match") TSRMLS_CC, (matches ? 3 : 2), regex, subject, matches, flags, offset);
-		} else {
-			//zephir_call_func_params(return_value, return_value_ptr, SL("preg_match") TSRMLS_CC, (matches ? 3 : 2), regex, subject, matches);
+			zephir_call_func_aparams(rvp, SL("preg_match"), NULL, 5, tmp_params TSRMLS_CC);
 		}
 	}
-
 	if (matches) {
 		Z_UNSET_ISREF_P(matches);
+	}
+
+	if (return_value) {
+		COPY_PZVAL_TO_ZVAL(*return_value, rv);
 	}
 }
 

--- a/ext/kernel/string.h
+++ b/ext/kernel/string.h
@@ -81,7 +81,7 @@ void zephir_substr(zval *return_value, zval *str, long from, long length, int fl
 zval *zephir_eol(int eol TSRMLS_DC);
 
 /** Preg-Match */
-void zephir_preg_match(zval *return_value, zval **return_value_ptr, zval *regex, zval *subject, zval *matches, int global, long flags, long offset TSRMLS_DC);
+void zephir_preg_match(zval *return_value, zval *regex, zval *subject, zval *matches, int global, long flags, long offset TSRMLS_DC);
 
 /** Base64 */
 void zephir_base64_encode(zval *return_value, zval *data);

--- a/test/pregmatch.zep
+++ b/test/pregmatch.zep
@@ -90,14 +90,31 @@ class Pregmatch
 		return preg_match(pattern, subject, matches, flags, offset);
 	}
 
-    /**
-     * @link https://github.com/phalcon/zephir/issues/287
-     */
-    public function testPregMatchSaveMatches(string str, string pattern)
-    {
-        var matches = null;
-        preg_match(pattern, str, matches);
+	/**
+	 * @link https://github.com/phalcon/zephir/issues/287
+	 */
+	public function testPregMatchSaveMatches(string str, string pattern)
+	{
+		var matches = null;
+		preg_match(pattern, str, matches);
 
-        return matches;
-    }
+		return matches;
+	}
+
+	public function testMatchAll(var flags)
+	{
+		var text, matches = [];
+		let text = "test1,test2";
+		preg_match_all("/(test[0-9]+)/", text, matches, flags);
+		return matches;
+	}
+
+	public function testMatchAllInZep()
+	{
+		var m1, m2;
+		let m1 = this->testMatchAll(PREG_PATTERN_ORDER);
+		let m2 = this->testMatchAll(PREG_SET_ORDER);
+
+		return [m1, m2];
+	}
 }

--- a/unit-tests/Extension/PregmatchTest.php
+++ b/unit-tests/Extension/PregmatchTest.php
@@ -26,7 +26,6 @@ class PregmatchTest extends \PHPUnit_Framework_TestCase
     public function testPregMatch()
     {
         $t = new Pregmatch();
-
         $this->assertSame(1, $t->testWithoutReturnAndMatches());
         $this->assertSame(array('def'), $t->testWithoutReturns());
         $this->assertSame(1, $t->testWithoutMatches());
@@ -73,5 +72,16 @@ class PregmatchTest extends \PHPUnit_Framework_TestCase
     {
         $t = new Pregmatch;
         $this->assertSame(array('asd'), $t->testPregMatchSaveMatches("asd", "#asd#"));
+    }
+    
+    /**
+     * @link https://github.com/phalcon/zephir/issues/144
+     */
+    public function testPregMatchAllFlags()
+    {
+        $t = new Pregmatch;
+        $arr = $t->testMatchAllInZep();
+        $this->assertEquals($arr[0], array(array('test1', 'test2'), array('test1', 'test2')));
+        $this->assertEquals($arr[1], array(array('test1', 'test1'), array('test2', 'test2')));
     }
 }


### PR DESCRIPTION
- Also added some additional tests
- Fixed the fallback implementation, when no PCRE is available during compilation.

Any other issues the current implementation has, which have to be fixed?