### PR TITLE
Fix #894: Static property access may observe non-tracked temp variables

### DIFF
--- a/Library/Expression/StaticPropertyAccess.php
+++ b/Library/Expression/StaticPropertyAccess.php
@@ -154,15 +154,8 @@ class StaticPropertyAccess
 
         $compilationContext->headersManager->add('kernel/object');
 
-        if ($classDefinition == $compilationContext->classDefinition) {
-            if ($this->_readOnly) {
-                $compilationContext->codePrinter->output($symbolVariable->getName() . ' = zephir_fetch_static_property_ce(' . $classDefinition->getClassEntry() . ', SL("' . $property . '") TSRMLS_CC);');
-            } else {
-                if ($symbolVariable->getName() != 'return_value') {
-                    $symbolVariable->observeVariant($compilationContext);
-                }
-                $compilationContext->codePrinter->output('zephir_read_static_property_ce(&' . $symbolVariable->getName() . ', ' . $classDefinition->getClassEntry() . ', SL("' . $property . '") TSRMLS_CC);');
-            }
+        if ($this->_readOnly) {
+            $compilationContext->codePrinter->output($symbolVariable->getName() . ' = zephir_fetch_static_property_ce(' . $classDefinition->getClassEntry() . ', SL("' . $property . '") TSRMLS_CC);');
         } else {
             if ($symbolVariable->getName() != 'return_value') {
                 $symbolVariable->observeVariant($compilationContext);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - PHP_VERSION: 5.6.7
+  - PHP_VERSION: 5.6.8
     PHP_DEP_VER: 5.6
   BUILD_PLATFORM: x86
   PHP_VC: 11


### PR DESCRIPTION
This bug was quite annoying to track down,
since unfortunately it corrupted values far before it crashed.

Details are in the respective issue, finally getting some sleep after hours of investigating.