### PR TITLE
Stubs now have consistent (and customisable) indentation.

### DIFF
--- a/Library/Stubs/DocBlock.php
+++ b/Library/Stubs/DocBlock.php
@@ -39,11 +39,11 @@ class DocBlock
 
     /**
      * @param string $source Raw doc-block
-     * @param int    $indent Indent size, 4 by default
+     * @param string $indent Indent, 4 spaces by default
      */
-    public function __construct($source, $indent = 4)
+    public function __construct($source, $indent = '    ')
     {
-        $this->indent = str_repeat(' ', $indent);
+        $this->indent = $indent;
 
         foreach (explode("\n", trim($source, '/')) as $line) {
             $line = trim($line, "\t*\0 ");

--- a/Library/Stubs/MethodDocBlock.php
+++ b/Library/Stubs/MethodDocBlock.php
@@ -38,7 +38,7 @@ class MethodDocBlock extends DocBlock
      */
     private $aliasManager;
 
-    public function __construct(ClassMethod $method, AliasManager $aliasManager, $indent = 4)
+    public function __construct(ClassMethod $method, AliasManager $aliasManager, $indent = '    ')
     {
         parent::__construct($method->getDocBlock(), $indent);
 


### PR DESCRIPTION
Previously, the indentation in stub files were a mixture of spaces and tabs ([see here for an example](https://github.com/phalcon/phalcon-devtools/blob/a7e20addd01c9bc1121cbb68531cd55523320af3/ide/2.0.0/Phalcon/Crypt.php#L46)).

Now, the indentation is consistent and by default is 4 spaces. You can also choose to use tabs by running:

```bash
zephir stubs --indent=tabs
```

I've had to change the behaviour of some method signatures (notably `Zephir\Stubs\MethodDocBlock::_construct()` and `Zephir\Stubs\DocBlock::_construct()`) but as they're not used anywhere else I think it's OK.