### PR TITLE
Fixed #740 issue

### DIFF
--- a/Library/Statements/ThrowStatement.php
+++ b/Library/Statements/ThrowStatement.php
@@ -84,12 +84,12 @@ class ThrowStatement extends StatementAbstract
         $throwExpr = new Expression($expr);
         $resolvedExpr = $throwExpr->compile($compilationContext);
 
-        if ($resolvedExpr->getType() != 'variable') {
+        if (!in_array($resolvedExpr->getType(), array('variable', 'string'))) {
             throw new CompilerException("Expression '" . $resolvedExpr->getType() . '" cannot be used as exception', $expr);
         }
 
         $variableVariable = $compilationContext->symbolTable->getVariableForRead($resolvedExpr->getCode(), $compilationContext, $expr);
-        if ($variableVariable->getType() != 'variable') {
+        if (!in_array($variableVariable->getType(), array('variable', 'string'))) {
             throw new CompilerException("Variable '" . $variableVariable->getType() . "' cannot be used as exception", $expr);
         }
 

--- a/ext/kernel/concat.c
+++ b/ext/kernel/concat.c
@@ -3,9 +3,9 @@
 #include "config.h"
 #endif
 
-#include "php.h"
+#include <php.h>
 #include "php_ext.h"
-#include "ext/standard/php_string.h"
+#include <ext/standard/php_string.h>
 #include "ext.h"
 
 #include "kernel/main.h"
@@ -224,6 +224,66 @@ void zephir_concat_svs(zval **result, const char *op1, zend_uint op1_len, zval *
 
 	if (use_copy2) {
 	   zval_dtor(op2);
+	}
+
+	if (use_copy) {
+	   zval_dtor(&result_copy);
+	}
+
+}
+
+void zephir_concat_svsv(zval **result, const char *op1, zend_uint op1_len, zval *op2, const char *op3, zend_uint op3_len, zval *op4, int self_var TSRMLS_DC){
+
+	zval result_copy, op2_copy, op4_copy;
+	int use_copy = 0, use_copy2 = 0, use_copy4 = 0;
+	uint offset = 0, length;
+
+	if (Z_TYPE_P(op2) != IS_STRING) {
+	   zend_make_printable_zval(op2, &op2_copy, &use_copy2);
+	   if (use_copy2) {
+	       op2 = &op2_copy;
+	   }
+	}
+
+	if (Z_TYPE_P(op4) != IS_STRING) {
+	   zend_make_printable_zval(op4, &op4_copy, &use_copy4);
+	   if (use_copy4) {
+	       op4 = &op4_copy;
+	   }
+	}
+
+	length = op1_len + Z_STRLEN_P(op2) + op3_len + Z_STRLEN_P(op4);
+	if (self_var) {
+
+		if (Z_TYPE_PP(result) != IS_STRING) {
+			zend_make_printable_zval(*result, &result_copy, &use_copy);
+			if (use_copy) {
+				ZEPHIR_CPY_WRT_CTOR(*result, (&result_copy));
+			}
+		}
+
+		offset = Z_STRLEN_PP(result);
+		length += offset;
+		Z_STRVAL_PP(result) = (char *) str_erealloc(Z_STRVAL_PP(result), length + 1);
+
+	} else {
+		Z_STRVAL_PP(result) = (char *) emalloc(length + 1);
+	}
+
+	memcpy(Z_STRVAL_PP(result) + offset, op1, op1_len);
+	memcpy(Z_STRVAL_PP(result) + offset + op1_len, Z_STRVAL_P(op2), Z_STRLEN_P(op2));
+	memcpy(Z_STRVAL_PP(result) + offset + op1_len + Z_STRLEN_P(op2), op3, op3_len);
+	memcpy(Z_STRVAL_PP(result) + offset + op1_len + Z_STRLEN_P(op2) + op3_len, Z_STRVAL_P(op4), Z_STRLEN_P(op4));
+	Z_STRVAL_PP(result)[length] = 0;
+	Z_TYPE_PP(result) = IS_STRING;
+	Z_STRLEN_PP(result) = length;
+
+	if (use_copy2) {
+	   zval_dtor(op2);
+	}
+
+	if (use_copy4) {
+	   zval_dtor(op4);
 	}
 
 	if (use_copy) {

--- a/ext/kernel/concat.h
+++ b/ext/kernel/concat.h
@@ -5,6 +5,8 @@
 #include <php.h>
 #include <Zend/zend.h>
 
+#include "kernel/main.h"
+
 #define ZEPHIR_CONCAT_SS(result, op1, op2) \
 	 zephir_concat_ss(&result, op1, sizeof(op1)-1, op2, sizeof(op2)-1, 0 TSRMLS_CC);
 #define ZEPHIR_SCONCAT_SS(result, op1, op2) \
@@ -30,6 +32,11 @@
 #define ZEPHIR_SCONCAT_SVS(result, op1, op2, op3) \
 	 zephir_concat_svs(&result, op1, sizeof(op1)-1, op2, op3, sizeof(op3)-1, 1 TSRMLS_CC);
 
+#define ZEPHIR_CONCAT_SVSV(result, op1, op2, op3, op4) \
+	 zephir_concat_svsv(&result, op1, sizeof(op1)-1, op2, op3, sizeof(op3)-1, op4, 0 TSRMLS_CC);
+#define ZEPHIR_SCONCAT_SVSV(result, op1, op2, op3, op4) \
+	 zephir_concat_svsv(&result, op1, sizeof(op1)-1, op2, op3, sizeof(op3)-1, op4, 1 TSRMLS_CC);
+
 #define ZEPHIR_CONCAT_VS(result, op1, op2) \
 	 zephir_concat_vs(&result, op1, op2, sizeof(op2)-1, 0 TSRMLS_CC);
 #define ZEPHIR_SCONCAT_VS(result, op1, op2) \
@@ -51,6 +58,7 @@ void zephir_concat_sssssss(zval **result, const char *op1, zend_uint op1_len, co
 void zephir_concat_ssv(zval **result, const char *op1, zend_uint op1_len, const char *op2, zend_uint op2_len, zval *op3, int self_var TSRMLS_DC);
 void zephir_concat_sv(zval **result, const char *op1, zend_uint op1_len, zval *op2, int self_var TSRMLS_DC);
 void zephir_concat_svs(zval **result, const char *op1, zend_uint op1_len, zval *op2, const char *op3, zend_uint op3_len, int self_var TSRMLS_DC);
+void zephir_concat_svsv(zval **result, const char *op1, zend_uint op1_len, zval *op2, const char *op3, zend_uint op3_len, zval *op4, int self_var TSRMLS_DC);
 void zephir_concat_vs(zval **result, zval *op1, const char *op2, zend_uint op2_len, int self_var TSRMLS_DC);
 void zephir_concat_vv(zval **result, zval *op1, zval *op2, int self_var TSRMLS_DC);
 void zephir_concat_vvv(zval **result, zval *op1, zval *op2, zval *op3, int self_var TSRMLS_DC);

--- a/ext/kernel/exception.c
+++ b/ext/kernel/exception.c
@@ -45,13 +45,20 @@ void zephir_throw_exception(zval *object TSRMLS_DC){
 /**
  * Throws a zval object as exception
  */
-void zephir_throw_exception_debug(zval *object, const char *file, zend_uint line TSRMLS_DC){
+void zephir_throw_exception_debug(zval *object, const char *file, zend_uint line TSRMLS_DC) {
 
 	zend_class_entry *default_exception_ce;
 	int ZEPHIR_LAST_CALL_STATUS = 0;
-	zval *curline = NULL;
+	zval *curline = NULL, *object_copy = NULL;
 
 	ZEPHIR_MM_GROW();
+
+	if (Z_TYPE_P(object) != IS_OBJECT) {
+		object_copy = object;
+		ALLOC_INIT_ZVAL(object);
+		object_init_ex(object, zend_exception_get_default(TSRMLS_C));
+		ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, object_copy);
+	}
 
 	Z_ADDREF_P(object);
 
@@ -61,8 +68,8 @@ void zephir_throw_exception_debug(zval *object, const char *file, zend_uint line
 		zephir_check_call_status();
 		if (ZEPHIR_IS_LONG(curline, 0)) {
 			default_exception_ce = zend_exception_get_default(TSRMLS_C);
-			zend_update_property_string(default_exception_ce, object, "file", sizeof("file")-1, file TSRMLS_CC);
-			zend_update_property_long(default_exception_ce, object, "line", sizeof("line")-1, line TSRMLS_CC);
+			zend_update_property_string(default_exception_ce, object, "file", sizeof("file") - 1, file TSRMLS_CC);
+			zend_update_property_long(default_exception_ce, object, "line", sizeof("line") - 1, line TSRMLS_CC);
 		}
 	}
 
@@ -189,4 +196,3 @@ void zephir_throw_exception_zval(zend_class_entry *ce, zval *message TSRMLS_DC){
 
 	zend_throw_exception_object(object TSRMLS_CC);
 }
-

--- a/ext/test/exceptions.zep.c
+++ b/ext/test/exceptions.zep.c
@@ -16,6 +16,7 @@
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
 #include "kernel/operators.h"
+#include "kernel/concat.h"
 #include "kernel/object.h"
 
 
@@ -171,6 +172,49 @@ PHP_METHOD(Test_Exceptions, testExceptionLiteral) {
 
 }
 
+PHP_METHOD(Test_Exceptions, testExceptionSprintf) {
+
+	int ZEPHIR_LAST_CALL_STATUS;
+	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zval *name_param = NULL, _0, *_1 = NULL;
+	zval *name = NULL;
+
+	ZEPHIR_MM_GROW();
+	zephir_fetch_params(1, 1, 0, &name_param);
+
+	zephir_get_strval(name, name_param);
+
+
+	ZEPHIR_SINIT_VAR(_0);
+	ZVAL_STRING(&_0, "Hello, %s", 0);
+	ZEPHIR_CALL_FUNCTION(&_1, "sprintf", &_2, &_0, name);
+	zephir_check_call_status();
+	zephir_throw_exception_debug(_1, "test/exceptions.zep", 65 TSRMLS_CC);
+	ZEPHIR_MM_RESTORE();
+	return;
+
+}
+
+PHP_METHOD(Test_Exceptions, testExceptionConcat) {
+
+	zval *framework_param = NULL, *language_param = NULL;
+	zval *framework = NULL, *language = NULL, *_0;
+
+	ZEPHIR_MM_GROW();
+	zephir_fetch_params(1, 2, 0, &framework_param, &language_param);
+
+	zephir_get_strval(framework, framework_param);
+	zephir_get_strval(language, language_param);
+
+
+	ZEPHIR_INIT_VAR(_0);
+	ZEPHIR_CONCAT_SVSV(_0, "Framework ", framework, " written using ", language);
+	zephir_throw_exception_debug(_0, "test/exceptions.zep", 70 TSRMLS_CC);
+	ZEPHIR_MM_RESTORE();
+	return;
+
+}
+
 PHP_METHOD(Test_Exceptions, testExceptionRethrow) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
@@ -190,7 +234,7 @@ PHP_METHOD(Test_Exceptions, testExceptionRethrow) {
 		ZEPHIR_CPY_WRT(e, EG(exception));
 		if (zephir_instance_of_ev(e, zend_exception_get_default(TSRMLS_C) TSRMLS_CC)) {
 			zend_clear_exception(TSRMLS_C);
-			zephir_throw_exception_debug(e, "test/exceptions.zep", 70 TSRMLS_CC);
+			zephir_throw_exception_debug(e, "test/exceptions.zep", 80 TSRMLS_CC);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}

--- a/ext/test/exceptions.zep.h
+++ b/ext/test/exceptions.zep.h
@@ -11,10 +11,21 @@ PHP_METHOD(Test_Exceptions, getException);
 PHP_METHOD(Test_Exceptions, testException4);
 PHP_METHOD(Test_Exceptions, testException5);
 PHP_METHOD(Test_Exceptions, testExceptionLiteral);
+PHP_METHOD(Test_Exceptions, testExceptionSprintf);
+PHP_METHOD(Test_Exceptions, testExceptionConcat);
 PHP_METHOD(Test_Exceptions, testExceptionRethrow);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_test_exceptions_testexceptionliteral, 0, 0, 1)
 	ZEND_ARG_INFO(0, type)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_test_exceptions_testexceptionsprintf, 0, 0, 1)
+	ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_test_exceptions_testexceptionconcat, 0, 0, 2)
+	ZEND_ARG_INFO(0, framework)
+	ZEND_ARG_INFO(0, language)
 ZEND_END_ARG_INFO()
 
 ZEPHIR_INIT_FUNCS(test_exceptions_method_entry) {
@@ -26,6 +37,8 @@ ZEPHIR_INIT_FUNCS(test_exceptions_method_entry) {
 	PHP_ME(Test_Exceptions, testException4, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Exceptions, testException5, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Exceptions, testExceptionLiteral, arginfo_test_exceptions_testexceptionliteral, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Exceptions, testExceptionSprintf, arginfo_test_exceptions_testexceptionsprintf, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Exceptions, testExceptionConcat, arginfo_test_exceptions_testexceptionconcat, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Exceptions, testExceptionRethrow, NULL, ZEND_ACC_PUBLIC)
   PHP_FE_END
 };

--- a/ext/test/internalclasses.zep.c
+++ b/ext/test/internalclasses.zep.c
@@ -31,7 +31,7 @@ PHP_METHOD(Test_InternalClasses, testStaticCall) {
 
 	ZEPHIR_MM_GROW();
 
-	_0 = zend_fetch_class(SL("Phalcon\\Di"), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
+	_0 = zend_fetch_class(SL("Phalcon\\DI"), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 	ZEPHIR_RETURN_CALL_CE_STATIC(_0, "getdefault", NULL);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/test/pregmatch.zep.c
+++ b/ext/test/pregmatch.zep.c
@@ -13,8 +13,10 @@
 
 #include "kernel/main.h"
 #include "kernel/memory.h"
+#include "kernel/string.h"
 #include "kernel/fcall.h"
 #include "kernel/operators.h"
+#include "kernel/array.h"
 
 
 ZEPHIR_INIT_CLASS(Test_Pregmatch) {
@@ -27,9 +29,7 @@ ZEPHIR_INIT_CLASS(Test_Pregmatch) {
 
 PHP_METHOD(Test_Pregmatch, testWithoutReturnAndMatches) {
 
-	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
-	zval *pattern, *subject;
+	zval *pattern, *subject, *_0, *_1, *_2;
 
 	ZEPHIR_MM_GROW();
 
@@ -37,19 +37,18 @@ PHP_METHOD(Test_Pregmatch, testWithoutReturnAndMatches) {
 	ZVAL_STRING(pattern, "/def$/", 1);
 	ZEPHIR_INIT_VAR(subject);
 	ZVAL_STRING(subject, "abcdef", 1);
-	ZEPHIR_CALL_FUNCTION(NULL, "preg_match", &_0, pattern, subject);
-	zephir_check_call_status();
-	ZEPHIR_RETURN_CALL_FUNCTION("preg_match", &_0, pattern, subject);
-	zephir_check_call_status();
+	ZEPHIR_INIT_VAR(_0);
+	ZEPHIR_INIT_VAR(_1);
+	zephir_preg_match(_1, pattern, subject, _0, 0, 0 , 0  TSRMLS_CC);
+	ZEPHIR_INIT_VAR(_2);
+	zephir_preg_match(return_value, pattern, subject, _2, 0, 0 , 0  TSRMLS_CC);
 	RETURN_MM();
 
 }
 
 PHP_METHOD(Test_Pregmatch, testWithoutReturns) {
 
-	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
-	zval *pattern, *subject, *matches = NULL;
+	zval *pattern, *subject, *matches = NULL, *_0;
 
 	ZEPHIR_MM_GROW();
 	ZEPHIR_INIT_VAR(matches);
@@ -59,19 +58,15 @@ PHP_METHOD(Test_Pregmatch, testWithoutReturns) {
 	ZVAL_STRING(pattern, "/def$/", 1);
 	ZEPHIR_INIT_VAR(subject);
 	ZVAL_STRING(subject, "abcdef", 1);
-	Z_SET_ISREF_P(matches);
-	ZEPHIR_CALL_FUNCTION(NULL, "preg_match", &_0, pattern, subject, matches);
-	Z_UNSET_ISREF_P(matches);
-	zephir_check_call_status();
+	ZEPHIR_INIT_VAR(_0);
+	zephir_preg_match(_0, pattern, subject, matches, 0, 0 , 0  TSRMLS_CC);
 	RETURN_CCTOR(matches);
 
 }
 
 PHP_METHOD(Test_Pregmatch, testWithoutMatches) {
 
-	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
-	zval *pattern, *subject, *matched = NULL;
+	zval *pattern, *subject, *matched, *_0;
 
 	ZEPHIR_MM_GROW();
 
@@ -79,16 +74,15 @@ PHP_METHOD(Test_Pregmatch, testWithoutMatches) {
 	ZVAL_STRING(pattern, "/def$/", 1);
 	ZEPHIR_INIT_VAR(subject);
 	ZVAL_STRING(subject, "abcdef", 1);
-	ZEPHIR_CALL_FUNCTION(&matched, "preg_match", &_0, pattern, subject);
-	zephir_check_call_status();
+	ZEPHIR_INIT_VAR(_0);
+	ZEPHIR_INIT_VAR(matched);
+	zephir_preg_match(matched, pattern, subject, _0, 0, 0 , 0  TSRMLS_CC);
 	RETURN_CCTOR(matched);
 
 }
 
 PHP_METHOD(Test_Pregmatch, testPregMatchAll) {
 
-	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
 	zval *pattern, *subject, *results;
 
 	ZEPHIR_MM_GROW();
@@ -99,10 +93,7 @@ PHP_METHOD(Test_Pregmatch, testPregMatchAll) {
 	ZVAL_STRING(pattern, "/def$/", 1);
 	ZEPHIR_INIT_VAR(subject);
 	ZVAL_STRING(subject, "abcdef", 1);
-	Z_SET_ISREF_P(results);
-	ZEPHIR_RETURN_CALL_FUNCTION("preg_match_all", &_0, pattern, subject, results);
-	Z_UNSET_ISREF_P(results);
-	zephir_check_call_status();
+	zephir_preg_match(return_value, pattern, subject, results, 1, 0 , 0  TSRMLS_CC);
 	RETURN_MM();
 
 }
@@ -137,37 +128,29 @@ PHP_METHOD(Test_Pregmatch, testPregMatchFallback) {
 
 PHP_METHOD(Test_Pregmatch, testPregMatch2Params) {
 
-	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
-	zval *pattern, *subject;
+	zval *pattern, *subject, *_0;
 
 	ZEPHIR_MM_GROW();
 	zephir_fetch_params(1, 2, 0, &pattern, &subject);
 
 
 
-	ZEPHIR_RETURN_CALL_FUNCTION("preg_match", &_0, pattern, subject);
-	zephir_check_call_status();
+	ZEPHIR_INIT_VAR(_0);
+	zephir_preg_match(return_value, pattern, subject, _0, 0, 0 , 0  TSRMLS_CC);
 	RETURN_MM();
 
 }
 
 PHP_METHOD(Test_Pregmatch, testPregMatch3Params) {
 
-	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
 	zval *pattern, *subject, *matches;
 
-	ZEPHIR_MM_GROW();
-	zephir_fetch_params(1, 3, 0, &pattern, &subject, &matches);
+	zephir_fetch_params(0, 3, 0, &pattern, &subject, &matches);
 
 
 
-	Z_SET_ISREF_P(matches);
-	ZEPHIR_RETURN_CALL_FUNCTION("preg_match", &_0, pattern, subject, matches);
-	Z_UNSET_ISREF_P(matches);
-	zephir_check_call_status();
-	RETURN_MM();
+	zephir_preg_match(return_value, pattern, subject, matches, 0, 0 , 0  TSRMLS_CC);
+	return;
 
 }
 
@@ -214,9 +197,7 @@ PHP_METHOD(Test_Pregmatch, testPregMatch5Params) {
  */
 PHP_METHOD(Test_Pregmatch, testPregMatchSaveMatches) {
 
-	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
-	zval *str_param = NULL, *pattern_param = NULL, *matches = NULL;
+	zval *str_param = NULL, *pattern_param = NULL, *matches = NULL, *_0;
 	zval *str = NULL, *pattern = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -228,11 +209,58 @@ PHP_METHOD(Test_Pregmatch, testPregMatchSaveMatches) {
 	ZVAL_NULL(matches);
 
 
+	ZEPHIR_INIT_VAR(_0);
+	zephir_preg_match(_0, pattern, str, matches, 0, 0 , 0  TSRMLS_CC);
+	RETURN_CCTOR(matches);
+
+}
+
+PHP_METHOD(Test_Pregmatch, testMatchAll) {
+
+	int ZEPHIR_LAST_CALL_STATUS;
+	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zval *flags, *text, *matches, *_0;
+
+	ZEPHIR_MM_GROW();
+	zephir_fetch_params(1, 1, 0, &flags);
+
+	ZEPHIR_INIT_VAR(matches);
+	array_init(matches);
+
+
+	ZEPHIR_INIT_VAR(text);
+	ZVAL_STRING(text, "test1,test2", 1);
+	ZEPHIR_INIT_VAR(_0);
+	ZVAL_STRING(_0, "/(test[0-9]+)/", ZEPHIR_TEMP_PARAM_COPY);
 	Z_SET_ISREF_P(matches);
-	ZEPHIR_CALL_FUNCTION(NULL, "preg_match", &_0, pattern, str, matches);
+	ZEPHIR_CALL_FUNCTION(NULL, "preg_match_all", &_1, _0, text, matches, flags);
+	zephir_check_temp_parameter(_0);
 	Z_UNSET_ISREF_P(matches);
 	zephir_check_call_status();
 	RETURN_CCTOR(matches);
+
+}
+
+PHP_METHOD(Test_Pregmatch, testMatchAllInZep) {
+
+	zephir_fcall_cache_entry *_1 = NULL;
+	int ZEPHIR_LAST_CALL_STATUS;
+	zval *m1 = NULL, *m2 = NULL, *_0 = NULL;
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_INIT_VAR(_0);
+	ZVAL_LONG(_0, 1);
+	ZEPHIR_CALL_METHOD(&m1, this_ptr, "testmatchall", &_1, _0);
+	zephir_check_call_status();
+	ZEPHIR_INIT_NVAR(_0);
+	ZVAL_LONG(_0, 2);
+	ZEPHIR_CALL_METHOD(&m2, this_ptr, "testmatchall", &_1, _0);
+	zephir_check_call_status();
+	zephir_create_array(return_value, 2, 0 TSRMLS_CC);
+	zephir_array_fast_append(return_value, m1);
+	zephir_array_fast_append(return_value, m2);
+	RETURN_MM();
 
 }
 

--- a/ext/test/pregmatch.zep.h
+++ b/ext/test/pregmatch.zep.h
@@ -13,6 +13,8 @@ PHP_METHOD(Test_Pregmatch, testPregMatch3Params);
 PHP_METHOD(Test_Pregmatch, testPregMatch4Params);
 PHP_METHOD(Test_Pregmatch, testPregMatch5Params);
 PHP_METHOD(Test_Pregmatch, testPregMatchSaveMatches);
+PHP_METHOD(Test_Pregmatch, testMatchAll);
+PHP_METHOD(Test_Pregmatch, testMatchAllInZep);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_test_pregmatch_testpregmatch2params, 0, 0, 2)
 	ZEND_ARG_INFO(0, pattern)
@@ -45,6 +47,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_test_pregmatch_testpregmatchsavematches, 0, 0, 2)
 	ZEND_ARG_INFO(0, pattern)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_test_pregmatch_testmatchall, 0, 0, 1)
+	ZEND_ARG_INFO(0, flags)
+ZEND_END_ARG_INFO()
+
 ZEPHIR_INIT_FUNCS(test_pregmatch_method_entry) {
 	PHP_ME(Test_Pregmatch, testWithoutReturnAndMatches, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Pregmatch, testWithoutReturns, NULL, ZEND_ACC_PUBLIC)
@@ -56,5 +62,7 @@ ZEPHIR_INIT_FUNCS(test_pregmatch_method_entry) {
 	PHP_ME(Test_Pregmatch, testPregMatch4Params, arginfo_test_pregmatch_testpregmatch4params, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Pregmatch, testPregMatch5Params, arginfo_test_pregmatch_testpregmatch5params, ZEND_ACC_PUBLIC)
 	PHP_ME(Test_Pregmatch, testPregMatchSaveMatches, arginfo_test_pregmatch_testpregmatchsavematches, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Pregmatch, testMatchAll, arginfo_test_pregmatch_testmatchall, ZEND_ACC_PUBLIC)
+	PHP_ME(Test_Pregmatch, testMatchAllInZep, NULL, ZEND_ACC_PUBLIC)
   PHP_FE_END
 };

--- a/ext/test/regexdna.zep.c
+++ b/ext/test/regexdna.zep.c
@@ -39,8 +39,8 @@ PHP_METHOD(Test_RegexDNA, process) {
 	HashTable *_5;
 	HashPosition _4;
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL, *_8 = NULL;
-	zval *path, *variants, *vIUB, *vIUBnew, *stuffToRemove, *contents = NULL, *initialLength, *regex = NULL, *codeLength, *discard = NULL, *_0 = NULL, *_1, *_2 = NULL, **_6, *_7 = NULL, *_9 = NULL;
+	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL;
+	zval *path, *variants, *vIUB, *vIUBnew, *stuffToRemove, *contents = NULL, *initialLength, *regex = NULL, *codeLength, *discard = NULL, *_0 = NULL, *_1, *_2 = NULL, **_6, *_7 = NULL;
 
 	ZEPHIR_MM_GROW();
 	zephir_fetch_params(1, 1, 0, &path);
@@ -174,18 +174,16 @@ PHP_METHOD(Test_RegexDNA, process) {
 		ZEPHIR_GET_HVALUE(regex, _6);
 		zend_print_zval(regex, 0);
 		php_printf("%s", " ");
+		ZEPHIR_INIT_NVAR(_0);
 		ZEPHIR_INIT_LNVAR(_7);
 		ZEPHIR_CONCAT_SVS(_7, "/", regex, "/iS");
-		Z_SET_ISREF_P(discard);
-		ZEPHIR_CALL_FUNCTION(&_2, "preg_match_all", &_8, _7, contents, discard);
-		Z_UNSET_ISREF_P(discard);
-		zephir_check_call_status();
-		zend_print_zval(_2, 0);
+		zephir_preg_match(_0, _7, contents, discard, 1, 0 , 0  TSRMLS_CC);
+		zend_print_zval(_0, 0);
 		php_printf("%c", '\n');
 	}
-	ZEPHIR_CALL_FUNCTION(&_9, "preg_replace", &_3, vIUB, vIUBnew, contents);
+	ZEPHIR_CALL_FUNCTION(&_2, "preg_replace", &_3, vIUB, vIUBnew, contents);
 	zephir_check_call_status();
-	ZEPHIR_CPY_WRT(contents, _9);
+	ZEPHIR_CPY_WRT(contents, _2);
 	php_printf("%c", '\n');
 	zend_print_zval(initialLength, 0);
 	php_printf("%c", '\n');

--- a/ext/test/router.zep.c
+++ b/ext/test/router.zep.c
@@ -415,12 +415,11 @@ PHP_METHOD(Test_Router, doRemoveExtraSlashes) {
  */
 PHP_METHOD(Test_Router, handle) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_9 = NULL;
 	zephir_fcall_cache_entry *_7 = NULL;
 	HashTable *_3, *_11;
 	HashPosition _2, _10;
 	int ZEPHIR_LAST_CALL_STATUS;
-	zval *uri = NULL, *realUri = NULL, *request = NULL, *currentHostName = NULL, *routeFound = NULL, *parts = NULL, *params = NULL, *matches, *notFoundPaths, *vnamespace, *module, *controller, *action, *paramsStr, *strParams, *paramsMerge = NULL, *route = NULL, *methods = NULL, *dependencyInjector = NULL, *hostname = NULL, *regexHostName = NULL, *matched = NULL, *pattern = NULL, *handledUri = NULL, *beforeMatch = NULL, *paths = NULL, *converters = NULL, *part = NULL, *position = NULL, *matchPosition = NULL, *_0, *_1, **_4, *_5, *_6 = NULL, *_8 = NULL, **_12, _13, *_14, *_15, *_16, *_17;
+	zval *uri = NULL, *realUri = NULL, *request = NULL, *currentHostName = NULL, *routeFound = NULL, *parts = NULL, *params = NULL, *matches, *notFoundPaths, *vnamespace, *module, *controller, *action, *paramsStr, *strParams, *paramsMerge = NULL, *route = NULL, *methods = NULL, *dependencyInjector = NULL, *hostname = NULL, *regexHostName = NULL, *matched = NULL, *pattern = NULL, *handledUri = NULL, *beforeMatch = NULL, *paths = NULL, *converters = NULL, *part = NULL, *position = NULL, *matchPosition = NULL, *_0, *_1, **_4, *_5, *_6 = NULL, *_8 = NULL, *_9 = NULL, **_12, _13, *_14, *_15, *_16, *_17;
 
 	ZEPHIR_MM_GROW();
 	zephir_fetch_params(1, 0, 1, &uri);
@@ -516,8 +515,9 @@ PHP_METHOD(Test_Router, handle) {
 				} else {
 					ZEPHIR_CPY_WRT(regexHostName, hostname);
 				}
-				ZEPHIR_CALL_FUNCTION(&matched, "preg_match", &_9, regexHostName, currentHostName);
-				zephir_check_call_status();
+				ZEPHIR_INIT_NVAR(_9);
+				ZEPHIR_INIT_NVAR(matched);
+				zephir_preg_match(matched, regexHostName, currentHostName, _9, 0, 0 , 0  TSRMLS_CC);
 			} else {
 				ZEPHIR_INIT_NVAR(matched);
 				ZVAL_BOOL(matched, ZEPHIR_IS_EQUAL(currentHostName, hostname));
@@ -529,10 +529,8 @@ PHP_METHOD(Test_Router, handle) {
 		ZEPHIR_CALL_METHOD(&pattern, route, "getcompiledpattern", NULL);
 		zephir_check_call_status();
 		if (zephir_memnstr_str(pattern, SL("^"), "test/router.zep", 399)) {
-			Z_SET_ISREF_P(matches);
-			ZEPHIR_CALL_FUNCTION(&routeFound, "preg_match", &_9, pattern, handledUri, matches);
-			Z_UNSET_ISREF_P(matches);
-			zephir_check_call_status();
+			ZEPHIR_INIT_NVAR(routeFound);
+			zephir_preg_match(routeFound, pattern, handledUri, matches, 0, 0 , 0  TSRMLS_CC);
 		} else {
 			ZEPHIR_INIT_NVAR(routeFound);
 			ZVAL_BOOL(routeFound, ZEPHIR_IS_EQUAL(pattern, handledUri));

--- a/test/exceptions.zep
+++ b/test/exceptions.zep
@@ -60,6 +60,16 @@ class Exceptions
         }
     }
 
+    public function testExceptionSprintf(string name)
+    {
+        throw sprintf("Hello, %s", name);
+    }
+
+    public function testExceptionConcat(string framework, string language)
+    {
+        throw "Framework " . framework . " written using " . language;
+    }
+
     public function testExceptionRethrow()
     {
         var e;

--- a/unit-tests/Extension/ExceptionsTest.php
+++ b/unit-tests/Extension/ExceptionsTest.php
@@ -113,6 +113,26 @@ class ExceptionsTest extends \PHPUnit_Framework_TestCase
         $t->testExceptionLiteral('double');
     }
 
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Hello, Zephir
+     */
+    public function testExceptionSprintf()
+    {
+        $t = new Exceptions();
+        $t->testExceptionSprintf('Zephir');
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Framework Phalcon written using Zephir
+     */
+    public function testExceptionConcat()
+    {
+        $t = new Exceptions();
+        $t->testExceptionConcat('Phalcon', 'Zephir');
+    }
+
     public function testExceptionRethrow()
     {
         $t = new Exceptions();


### PR DESCRIPTION
Inside compiler `sprintf` function returns variable with `variable` type.
This patch catch `sprintf` calls and convert them into `new Exception(sprintf(...))`.