### PR TITLE
Revert f58a4db5cac21d2b77e8af407fe42a0a9cde0c2b partially

### DIFF
--- a/Library/Cache/FunctionCache.php
+++ b/Library/Cache/FunctionCache.php
@@ -53,7 +53,7 @@ class FunctionCache
      *
      * @param CallGathererPass $gatherer
      */
-    public function __construct(CallGathererPass $gatherer)
+    public function __construct(CallGathererPass $gatherer = null)
     {
         $this->gatherer = $gatherer;
     }

--- a/Library/Cache/MethodCache.php
+++ b/Library/Cache/MethodCache.php
@@ -57,7 +57,7 @@ class MethodCache
      *
      * @param CallGathererPass $gatherer
      */
-    public function __construct(CallGathererPass $gatherer)
+    public function __construct(CallGathererPass $gatherer = null)
     {
         $this->gatherer = $gatherer;
     }


### PR DESCRIPTION
A gatherer is not required, it can be disabled or not needed
(no statements), which causes an exception -> zephir crash

(It being null in these cases is therefor perfectly valid)