### PR TITLE
Fix #679: Check for local variables and treat them accordingly

### DIFF
--- a/Library/Operators/Other/IssetOperator.php
+++ b/Library/Operators/Other/IssetOperator.php
@@ -98,17 +98,17 @@ class IssetOperator extends BaseOperator
 
                     case 'variable':
                         $indexVariable = $compilationContext->symbolTable->getVariableForRead($resolvedExpr->getCode(), $compilationContext, $left['right']);
-                        $indexVariable->setLocalOnly(false);
+                        $indexVariableName = ($indexVariable->isLocalOnly() ? '&' : '') . $indexVariable->getName();
 
                         switch ($indexVariable->getType()) {
 
                             case 'int':
                             case 'long':
-                                return new CompiledExpression('bool', 'zephir_array_isset_long(' . $variable->getName() . ', ' . $indexVariable->getName() . ')', $left['right']);
+                                return new CompiledExpression('bool', 'zephir_array_isset_long(' . $variable->getName() . ', ' . $indexVariableName . ')', $left['right']);
 
                             case 'variable':
                             case 'string':
-                                return new CompiledExpression('bool', 'zephir_array_isset(' . $variable->getName() . ', ' . $indexVariable->getName() . ')', $left['right']);
+                                return new CompiledExpression('bool', 'zephir_array_isset(' . $variable->getName() . ', ' . $indexVariableName . ')', $left['right']);
 
                             default:
                                 throw new CompilerException('[' . $indexVariable->getType() . ']', $expression);

--- a/Library/Statements/Let/ArrayIndex.php
+++ b/Library/Statements/Let/ArrayIndex.php
@@ -190,19 +190,20 @@ class ArrayIndex
 
             case 'variable':
                 $variableIndex = $compilationContext->symbolTable->getVariableForRead($exprIndex->getCode(), $compilationContext, $statement);
+                $variableIndexName = ($variableIndex->isLocalOnly() ? '&' : '') . $variableIndex->getName();
 
                 switch ($variableIndex->getType()) {
                     case 'int':
                     case 'uint':
                     case 'long':
                     case 'ulong':
-                        $codePrinter->output('zephir_array_update_long(&' . $variable . ', ' . $variableIndex->getName() . ', &' . $symbolVariable->getName() . ', ' . $flags . ', "' . Compiler::getShortUserPath($statement['index-expr'][0]['file']) . '", ' . $statement['index-expr'][0]['line'] . ');');
+                        $codePrinter->output('zephir_array_update_long(&' . $variable . ', ' . $variableIndexName . ', &' . $symbolVariable->getName() . ', ' . $flags . ', "' . Compiler::getShortUserPath($statement['index-expr'][0]['file']) . '", ' . $statement['index-expr'][0]['line'] . ');');
                         break;
                     case 'string':
-                        $codePrinter->output('zephir_array_update_zval(&' . $variable . ', ' . $variableIndex->getName() . ', &' . $symbolVariable->getName() . ', ' . $flags . ');');
+                        $codePrinter->output('zephir_array_update_zval(&' . $variable . ', ' . $variableIndexName . ', &' . $symbolVariable->getName() . ', ' . $flags . ');');
                         break;
                     case 'variable':
-                        $codePrinter->output('zephir_array_update_zval(&' . $variable . ', ' . $variableIndex->getName() . ', &' . $symbolVariable->getName() . ', ' . $flags . ');');
+                        $codePrinter->output('zephir_array_update_zval(&' . $variable . ', ' . $variableIndexName . ', &' . $symbolVariable->getName() . ', ' . $flags . ');');
                         break;
                     default:
                         throw new CompilerException("Variable: " . $variableIndex->getType() . " cannot be used as array index", $statement);


### PR DESCRIPTION
On isset do not convert a variable to "not local", to prevent
previous code from getting invalidated.

Check if the variable is only local and set the pointers accordingly.
