### PR TITLE
Kernel could not be created again

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -1107,12 +1107,11 @@ class Compiler
      */
     protected function checkKernelFiles()
     {
-        
         $kernelPath = "ext/kernel";
 
-        if(!file_exists($kernelPath)){
-            $kernelDone = mkdir($kernelPath,0775,true);
-            if(!$kernelDone){
+        if (!file_exists($kernelPath)) {
+            $kernelDone = mkdir($kernelPath, 0775, true);
+            if (!$kernelDone) {
                 throw new Exception("Cannot create kernel directory");
             }
         }

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -1107,7 +1107,17 @@ class Compiler
      */
     protected function checkKernelFiles()
     {
-        $kernelPath = realpath("ext/kernel");
+        
+        $kernelPath = "ext/kernel";
+
+        if(!file_exists($kernelPath)){
+            $kernelDone = mkdir($kernelPath,0775,true);
+            if(!$kernelDone){
+                throw new Exception("Cannot create kernel directory");
+            }
+        }
+
+        $kernelPath = realpath($kernelPath);
         $sourceKernelPath = realpath(__DIR__ . '/../ext/kernel');
 
         $configured = $this->recursiveProcess($sourceKernelPath, $kernelPath, '@.*\.[ch]$@', array($this, 'checkKernelFile'));


### PR DESCRIPTION
When you do ``rm -Rf ext`` then ``zephir build`` you  were getting an error because of this : https://github.com/phalcon/zephir/compare/master...gsouf:master#diff-248ceabfa20d5576b00171e114ec5d3dL1110

realpath does not work with non-existing files and was returning ``/ext/kernel`` instead of ``/path/to/zephir/project/ext/kernel``.