### PR TITLE
Win32: Update PHP version to 5.6.9, fix build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - PHP_VERSION: 5.6.8
+  - PHP_VERSION: 5.6.9
     PHP_DEP_VER: 5.6
   BUILD_PLATFORM: x86
   PHP_VC: 11


### PR DESCRIPTION
Fix the appveyor build to use the new php 5.6.9.