### PR TITLE
Do not define internal methods as PHP methods in generated headers

### DIFF
--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -1071,7 +1071,9 @@ class ClassDefinition
         if ($this->getType() == 'class') {
             if (count($methods)) {
                 foreach ($methods as $method) {
-                    $codePrinter->output('PHP_METHOD(' . $this->getCNamespace() . '_' . $this->getName() . ', ' . $method->getName() . ');');
+                    if (!$method->isInternal()) {
+                        $codePrinter->output('PHP_METHOD(' . $this->getCNamespace() . '_' . $this->getName() . ', ' . $method->getName() . ');');
+                    }
                 }
                 $codePrinter->outputBlankLine();
             }


### PR DESCRIPTION
Without the patch this leads to not resolved external symbols.