### PR TITLE
Internal functions: Implement static call, fix unused return value calls

### DIFF
--- a/Library/MethodCall.php
+++ b/Library/MethodCall.php
@@ -633,7 +633,7 @@ class MethodCall extends Call
                             $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_P0(&' . $symbolVariable->getName() . ', ' . $variableVariable->getName() . ', ' . $method->getInternalName() . ');');
                         }
                     } else {
-                        $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_P0(NULL, ' . $variableVariable->getName() . ', ' . $method->getInternalName() . ');');
+                        $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_NORETURN_P0(' . $variableVariable->getName() . ', ' . $method->getInternalName() . ');');
                     }
                 } else {
                     if ($isExpecting) {
@@ -643,7 +643,7 @@ class MethodCall extends Call
                             $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_P' . count($params) . '(&' . $symbolVariable->getName() . ', ' . $variableVariable->getName() . ', ' . $method->getInternalName() . ', ' . join(', ', $params) . ');');
                         }
                     } else {
-                        $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_P' . count($params) . '(NULL, ' . $variableVariable->getName() . ', ' . $method->getInternalName() . ', ' . join(', ', $params) . ');');
+                        $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_NORETURN_P' . count($params) . '(' . $variableVariable->getName() . ', ' . $method->getInternalName() . ', ' . join(', ', $params) . ');');
                     }
                 }
             }

--- a/Library/StaticCall.php
+++ b/Library/StaticCall.php
@@ -71,25 +71,54 @@ class StaticCall extends Call
             $params = array();
         }
 
-        if (!count($params)) {
-            if ($isExpecting) {
-                if ($symbolVariable->getName() == 'return_value') {
-                    $codePrinter->output('ZEPHIR_RETURN_CALL_' . $context . '("' . $methodName . '", ' . $cachePointer . ');');
+        $isInternal = false;
+        if (isset($method)) {
+            $isInternal = $method->isInternal();
+        }
+        
+        if (!$isInternal) {
+            if (!count($params)) {
+                if ($isExpecting) {
+                    if ($symbolVariable->getName() == 'return_value') {
+                        $codePrinter->output('ZEPHIR_RETURN_CALL_' . $context . '("' . $methodName . '", ' . $cachePointer . ');');
+                    } else {
+                        $codePrinter->output('ZEPHIR_CALL_' . $context . '(&' . $symbolVariable->getName() . ', "' . $methodName . '", ' . $cachePointer . ');');
+                    }
                 } else {
-                    $codePrinter->output('ZEPHIR_CALL_' . $context . '(&' . $symbolVariable->getName() . ', "' . $methodName . '", ' . $cachePointer . ');');
+                    $codePrinter->output('ZEPHIR_CALL_' . $context . '(NULL, "' . $methodName . '", ' . $cachePointer . ');');
                 }
             } else {
-                $codePrinter->output('ZEPHIR_CALL_' . $context . '(NULL, "' . $methodName . '", ' . $cachePointer . ');');
+                if ($isExpecting) {
+                    if ($symbolVariable->getName() == 'return_value') {
+                        $codePrinter->output('ZEPHIR_RETURN_CALL_' . $context . '("' . $methodName . '", ' . $cachePointer . ', ' . join(', ', $params) . ');');
+                    } else {
+                        $codePrinter->output('ZEPHIR_CALL_' . $context . '(&' . $symbolVariable->getName() . ', "' . $methodName . '", ' . $cachePointer . ', ' . join(', ', $params) . ');');
+                    }
+                } else {
+                    $codePrinter->output('ZEPHIR_CALL_' . $context . '(NULL, "' . $methodName . '", ' . $cachePointer . ', ' . join(', ', $params) . ');');
+                }
             }
         } else {
-            if ($isExpecting) {
-                if ($symbolVariable->getName() == 'return_value') {
-                    $codePrinter->output('ZEPHIR_RETURN_CALL_' . $context . '("' . $methodName . '", ' . $cachePointer . ', ' . join(', ', $params) . ');');
+            if (!count($params)) {
+                if ($isExpecting) {
+                    if ($symbolVariable->getName() == 'return_value') {
+                        $codePrinter->output('ZEPHIR_RETURN_CALL_INTERNAL_METHOD_P0(EG(This), ' . $method->getInternalName() . ');');
+                    } else {
+                        $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_P0(&' . $symbolVariable->getName() . ', EG(This), ' . $method->getInternalName() . ');');
+                    }
                 } else {
-                    $codePrinter->output('ZEPHIR_CALL_' . $context . '(&' . $symbolVariable->getName() . ', "' . $methodName . '", ' . $cachePointer . ', ' . join(', ', $params) . ');');
+                    $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_NORETURN_P0(EG(This), ' . $method->getInternalName() . ');');
                 }
             } else {
-                $codePrinter->output('ZEPHIR_CALL_' . $context . '(NULL, "' . $methodName . '", ' . $cachePointer . ', ' . join(', ', $params) . ');');
+                if ($isExpecting) {
+                    if ($symbolVariable->getName() == 'return_value') {
+                        $codePrinter->output('ZEPHIR_RETURN_CALL_INTERNAL_METHOD_P' . count($params) . '(EG(This), ' . $method->getInternalName() . ', ' . join(', ', $params) . ');');
+                    } else {
+                        $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_P' . count($params) . '(&' . $symbolVariable->getName() . ', EG(This), ' . $method->getInternalName() . ', ' . join(', ', $params) . ');');
+                    }
+                } else {
+                    $codePrinter->output('ZEPHIR_CALL_INTERNAL_METHOD_NORETURN_P' . count($params) . '(EG(This), ' . $method->getInternalName() . ', ' . join(', ', $params) . ');');
+                }
             }
         }
 

--- a/ext/kernel/fcall.h
+++ b/ext/kernel/fcall.h
@@ -227,14 +227,59 @@ typedef enum _zephir_call_type {
 		EG(This) = ZEPHIR_OLD_THIS_PTR; \
 	} while (0)
 
-#define ZEPHIR_CALL_INTERNAL_METHOD(return_value_ptr, object, method) \
+/**
+  * Call a internal method using a local return value ptr, since the return value isn't used
+  */
+#define ZEPHIR_CALL_INTERNAL_METHOD_NORETURN_P0(object, method) \
 	do { \
 		zval *ZEPHIR_OLD_THIS_PTR = this_ptr; \
+		zval *rv = NULL; \
+		zval **rvp = &rv; \
+		ALLOC_INIT_ZVAL(rv); \
 		EG(This) = object; \
-		ZEPHIR_INIT_NVAR(*return_value_ptr); \
-		method(0, *return_value_ptr, return_value_ptr, object, 1 TSRMLS_CC); \
+		method(0, rv, rvp, object, 0 TSRMLS_CC); \
 		ZEPHIR_LAST_CALL_STATUS = EG(exception) ? FAILURE : SUCCESS; \
 		EG(This) = ZEPHIR_OLD_THIS_PTR; \
+		zval_ptr_dtor(rvp); \
+	} while (0)
+
+#define ZEPHIR_CALL_INTERNAL_METHOD_NORETURN_P1(object, method, p1) \
+	do { \
+		zval *ZEPHIR_OLD_THIS_PTR = this_ptr; \
+		zval *rv = NULL; \
+		zval **rvp = &rv; \
+		ALLOC_INIT_ZVAL(rv); \
+		EG(This) = object; \
+		method(0, rv, rvp, object, 0, p1 TSRMLS_CC); \
+		ZEPHIR_LAST_CALL_STATUS = EG(exception) ? FAILURE : SUCCESS; \
+		EG(This) = ZEPHIR_OLD_THIS_PTR; \
+		zval_ptr_dtor(rvp); \
+	} while (0)
+
+#define ZEPHIR_CALL_INTERNAL_METHOD_NORETURN_P2(object, method, p1, p2) \
+	do { \
+		zval *ZEPHIR_OLD_THIS_PTR = this_ptr; \
+		zval *rv = NULL; \
+		zval **rvp = &rv; \
+		ALLOC_INIT_ZVAL(rv); \
+		EG(This) = object; \
+		method(0, rv, rvp, object, 0, p1, p2 TSRMLS_CC); \
+		ZEPHIR_LAST_CALL_STATUS = EG(exception) ? FAILURE : SUCCESS; \
+		EG(This) = ZEPHIR_OLD_THIS_PTR; \
+		zval_ptr_dtor(rvp); \
+	} while (0)
+	
+#define ZEPHIR_CALL_INTERNAL_METHOD_NORETURN_P3(object, method, p1, p2, p3) \
+	do { \
+		zval *ZEPHIR_OLD_THIS_PTR = this_ptr; \
+		zval *rv = NULL; \
+		zval **rvp = &rv; \
+		ALLOC_INIT_ZVAL(rv); \
+		EG(This) = object; \
+		method(0, rv, rvp, object, 0, p1, p2, p3 TSRMLS_CC); \
+		ZEPHIR_LAST_CALL_STATUS = EG(exception) ? FAILURE : SUCCESS; \
+		EG(This) = ZEPHIR_OLD_THIS_PTR; \
+		zval_ptr_dtor(rvp); \
 	} while (0)
 
 #define ZEPHIR_CALL_INTERNAL_METHOD_P0(return_value_ptr, object, method) \


### PR DESCRIPTION
Implement internal methods for static context like ``self::internalFunc`` (only self/static)
Also fix a null pointer dereference when the return value is not used further.
