### PR TITLE
Add checks for builtin (user defined) functions to reduce warnings

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -50,7 +50,7 @@ class Compiler
     /**
      * @var FunctionDefinition[]
      */
-    protected $functionDefinitions = array();
+    public $functionDefinitions = array();
 
     /**
      * @var array|string[]


### PR DESCRIPTION
Previously nonexistent-function warnings were spammed