### PR TITLE
Fix optimizers to init symbolVariable as late as possible

### DIFF
--- a/Library/Optimizers/FunctionCall/AddcslashesOptimizer.php
+++ b/Library/Optimizers/FunctionCall/AddcslashesOptimizer.php
@@ -61,16 +61,15 @@ class AddcslashesOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
 
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_addcslashes(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/AddslashesOptimizer.php
+++ b/Library/Optimizers/FunctionCall/AddslashesOptimizer.php
@@ -61,16 +61,15 @@ class AddslashesOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
 
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_addslashes(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/ArrayKeysOptimizer.php
+++ b/Library/Optimizers/FunctionCall/ArrayKeysOptimizer.php
@@ -60,15 +60,14 @@ class ArrayKeysOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/array');
 
         $symbolVariable->setDynamicTypes('array');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_array_keys(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/ArrayMergeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/ArrayMergeOptimizer.php
@@ -59,15 +59,14 @@ class ArrayMergeOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/array');
 
         $symbolVariable->setDynamicTypes('array');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_fast_array_merge(' . $symbolVariable->getName() . ', &(' . $resolvedParams[0] . '), &(' . $resolvedParams[1] . ') TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/BasenameOptimizer.php
+++ b/Library/Optimizers/FunctionCall/BasenameOptimizer.php
@@ -61,14 +61,14 @@ class BasenameOptimizer extends OptimizerAbstract
             if ($symbolVariable->isNotVariableAndString()) {
                 throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
             }
-
-            if ($call->mustInitSymbolVariable()) {
-                $symbolVariable->initVariant($context);
-            }
         }
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
+        
         $context->codePrinter->output('zephir_basename(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/CallUserFuncArrayOptimizer.php
+++ b/Library/Optimizers/FunctionCall/CallUserFuncArrayOptimizer.php
@@ -58,9 +58,6 @@ class CallUserFuncArrayOptimizer extends OptimizerAbstract
             if (!$symbolVariable->isVariable()) {
                 throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
             }
-            if ($call->mustInitSymbolVariable()) {
-                $symbolVariable->initVariant($context);
-            }
         } else {
             $symbolVariable = $context->symbolTable->addTemp('variable', $context);
             $symbolVariable->initVariant($context);
@@ -80,6 +77,10 @@ class CallUserFuncArrayOptimizer extends OptimizerAbstract
          */
         $call->addCallStatusFlag($context);
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
+        
         $context->codePrinter->output('ZEPHIR_CALL_USER_FUNC_ARRAY(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ');');
         $call->addCallStatusOrJump($context);
 

--- a/Library/Optimizers/FunctionCall/CallUserFuncOptimizer.php
+++ b/Library/Optimizers/FunctionCall/CallUserFuncOptimizer.php
@@ -58,9 +58,6 @@ class CallUserFuncOptimizer extends OptimizerAbstract
             if (!$symbolVariable->isVariable()) {
                 throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
             }
-            if ($call->mustInitSymbolVariable()) {
-                $symbolVariable->initVariant($context);
-            }
         } else {
             $symbolVariable = $context->symbolTable->addTemp('variable', $context);
             $symbolVariable->initVariant($context);
@@ -80,6 +77,10 @@ class CallUserFuncOptimizer extends OptimizerAbstract
          */
         $call->addCallStatusFlag($context);
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
+        
         $context->codePrinter->output('ZEPHIR_CALL_USER_FUNC(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ');');
         $call->addCallStatusOrJump($context);
 

--- a/Library/Optimizers/FunctionCall/Crc32Optimizer.php
+++ b/Library/Optimizers/FunctionCall/Crc32Optimizer.php
@@ -59,14 +59,13 @@ class Crc32Optimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
         $symbolVariable->setDynamicTypes('long');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_crc32(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/CreateArrayOptimizer.php
+++ b/Library/Optimizers/FunctionCall/CreateArrayOptimizer.php
@@ -57,10 +57,6 @@ class CreateArrayOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         /**
          * Add the last call status to the current symbol table
          */
@@ -76,6 +72,10 @@ class CreateArrayOptimizer extends OptimizerAbstract
             $resolvedParams = null;
         }
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
+        
         if ($resolvedParams) {
             $context->codePrinter->output('zephir_create_array(' . $symbolVariable->getName() . ', zephir_get_intval(' . $resolvedParams[0] . '), 1 TSRMLS_CC);');
         } else {

--- a/Library/Optimizers/FunctionCall/CreateInstanceOptimizer.php
+++ b/Library/Optimizers/FunctionCall/CreateInstanceOptimizer.php
@@ -59,10 +59,6 @@ class CreateInstanceOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         /**
          * Add the last call status to the current symbol table
          */
@@ -74,6 +70,9 @@ class CreateInstanceOptimizer extends OptimizerAbstract
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
          /**
          * Add the last call status to the current symbol table
          */

--- a/Library/Optimizers/FunctionCall/CreateInstanceParamsOptimizer.php
+++ b/Library/Optimizers/FunctionCall/CreateInstanceParamsOptimizer.php
@@ -58,10 +58,6 @@ class CreateInstanceParamsOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         /**
          * Add the last call status to the current symbol table
          */
@@ -72,7 +68,10 @@ class CreateInstanceParamsOptimizer extends OptimizerAbstract
         $symbolVariable->setDynamicTypes('object');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
-
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         /**
          * Add the last call status to the current symbol table
          */

--- a/Library/Optimizers/FunctionCall/EvalOptimizer.php
+++ b/Library/Optimizers/FunctionCall/EvalOptimizer.php
@@ -54,14 +54,13 @@ class EvalOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/fcall');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
-
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $evalContext = str_replace(ZEPHIRPATH, '', $expression['file'] . ':' . $expression['line']);
         $context->codePrinter->output(
             sprintf('zephir_eval_php(%s, %s, "%s" TSRMLS_CC);', $resolvedParams[0], $symbolVariable->getName(), $evalContext)

--- a/Library/Optimizers/FunctionCall/ExplodeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/ExplodeOptimizer.php
@@ -77,10 +77,6 @@ class ExplodeOptimizer extends OptimizerAbstract
             }
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 
         if (isset($resolvedParams[$limitOffset])) {
@@ -90,7 +86,10 @@ class ExplodeOptimizer extends OptimizerAbstract
 
         $context->headersManager->add('kernel/string');
         $symbolVariable->setDynamicTypes('array');
-
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
+        
         if (isset($str)) {
             $context->codePrinter->output('zephir_fast_explode_str(' . $symbolVariable->getName() . ', SL("' . $str . '"), ' . $resolvedParams[0] . ', ' . $limit . ' TSRMLS_CC);');
             return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);

--- a/Library/Optimizers/FunctionCall/FileGetContentsOptimizer.php
+++ b/Library/Optimizers/FunctionCall/FileGetContentsOptimizer.php
@@ -61,12 +61,12 @@ class FileGetContentsOptimizer extends OptimizerAbstract
             if ($symbolVariable->isNotVariableAndString()) {
                 throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
             }
-            if ($call->mustInitSymbolVariable()) {
-                $symbolVariable->initVariant($context);
-            }
         }
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         if ($symbolVariable) {
             $context->codePrinter->output('zephir_file_get_contents(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
             return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);

--- a/Library/Optimizers/FunctionCall/FilePutContentsOptimizer.php
+++ b/Library/Optimizers/FunctionCall/FilePutContentsOptimizer.php
@@ -61,13 +61,13 @@ class FilePutContentsOptimizer extends OptimizerAbstract
             if ($symbolVariable->isNotVariableAndString()) {
                 throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
             }
-            if ($call->mustInitSymbolVariable()) {
-                $symbolVariable->initVariant($context);
-            }
         }
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
         if ($symbolVariable) {
+            if ($call->mustInitSymbolVariable()) {
+                $symbolVariable->initVariant($context);
+            }
             $context->codePrinter->output('zephir_file_put_contents(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
             return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
         } else {

--- a/Library/Optimizers/FunctionCall/FilemtimeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/FilemtimeOptimizer.php
@@ -61,14 +61,12 @@ class FilemtimeOptimizer extends OptimizerAbstract
             if ($symbolVariable->isNotVariableAndString()) {
                 throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
             }
-
-            if ($call->mustInitSymbolVariable()) {
-                $symbolVariable->initVariant($context);
-            }
         }
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
-
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_filemtime(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/FwriteOptimizer.php
+++ b/Library/Optimizers/FunctionCall/FwriteOptimizer.php
@@ -61,14 +61,13 @@ class FwriteOptimizer extends OptimizerAbstract
             if ($symbolVariable->isNotVariableAndString()) {
                 throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
             }
-
-            if ($call->mustInitSymbolVariable()) {
-                $symbolVariable->initVariant($context);
-            }
         }
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
         if ($symbolVariable) {
+            if ($call->mustInitSymbolVariable()) {
+                $symbolVariable->initVariant($context);
+            }
             $context->codePrinter->output('zephir_fwrite(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
             return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
         } else {

--- a/Library/Optimizers/FunctionCall/GetClassLowerOptimizer.php
+++ b/Library/Optimizers/FunctionCall/GetClassLowerOptimizer.php
@@ -61,15 +61,14 @@ class GetClassLowerOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/object');
 
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_get_class(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', 1 TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/GetClassNsOptimizer.php
+++ b/Library/Optimizers/FunctionCall/GetClassNsOptimizer.php
@@ -61,15 +61,14 @@ class GetClassNsOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/object');
 
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         if (!isset($resolvedParams[1])) {
             $context->codePrinter->output('zephir_get_class_ns(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', 0 TSRMLS_CC);');
         } else {

--- a/Library/Optimizers/FunctionCall/GetClassOptimizer.php
+++ b/Library/Optimizers/FunctionCall/GetClassOptimizer.php
@@ -60,16 +60,14 @@ class GetClassOptimizer extends OptimizerAbstract
         if ($symbolVariable->isNotVariableAndString()) {
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
-
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/object');
 
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_get_class(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', 0 TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/GetNsClassOptimizer.php
+++ b/Library/Optimizers/FunctionCall/GetNsClassOptimizer.php
@@ -59,14 +59,14 @@ class GetNsClassOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/object');
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_get_ns_class(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', 0 TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/GettypeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/GettypeOptimizer.php
@@ -59,13 +59,13 @@ class GettypeOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_gettype(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/ImplodeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/ImplodeOptimizer.php
@@ -65,10 +65,6 @@ class ImplodeOptimizer extends OptimizerAbstract
             unset($expression['parameters'][0]);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 
         $context->headersManager->add('kernel/string');
@@ -79,6 +75,9 @@ class ImplodeOptimizer extends OptimizerAbstract
             return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
         }
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_fast_join(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/JoinOptimizer.php
+++ b/Library/Optimizers/FunctionCall/JoinOptimizer.php
@@ -66,10 +66,6 @@ class JoinOptimizer extends OptimizerAbstract
             unset($expression['parameters'][0]);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 
         $context->headersManager->add('kernel/string');
@@ -80,6 +76,9 @@ class JoinOptimizer extends OptimizerAbstract
             return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
         }
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_fast_join(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/JsonDecodeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/JsonDecodeOptimizer.php
@@ -56,9 +56,6 @@ class JsonDecodeOptimizer extends OptimizerAbstract
             if (!$symbolVariable->isVariable()) {
                 throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
             }
-            if ($call->mustInitSymbolVariable()) {
-                $symbolVariable->initVariant($context);
-            }
         } else {
             $symbolVariable = $context->symbolTable->addTemp('variable', $context);
             $symbolVariable->initVariant($context);
@@ -76,6 +73,10 @@ class JsonDecodeOptimizer extends OptimizerAbstract
             $options = 'zephir_get_intval(' . $resolvedParams[1] . ') ';
         } else {
             $options = '0 ';
+        }
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
         }
 
         $context->codePrinter->output('zephir_json_decode(' . $symbolVariable->getName() . ', &(' . $symbolVariable->getName() . '), ' . $resolvedParams[0] . ', '. $options .' TSRMLS_CC);');

--- a/Library/Optimizers/FunctionCall/JsonEncodeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/JsonEncodeOptimizer.php
@@ -55,9 +55,6 @@ class JsonEncodeOptimizer extends OptimizerAbstract
         if (!$symbolVariable->isVariable()) {
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
 
         $context->headersManager->add('kernel/string');
 
@@ -71,6 +68,10 @@ class JsonEncodeOptimizer extends OptimizerAbstract
             $options = 'zephir_get_intval(' . $resolvedParams[1] . ') ';
         } else {
             $options = '0 ';
+        }
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
         }
 
         $context->codePrinter->output('zephir_json_encode(' . $symbolVariable->getName() . ', &(' . $symbolVariable->getName() . '), ' . $resolvedParams[0] . ', '. $options .' TSRMLS_CC);');

--- a/Library/Optimizers/FunctionCall/Md5Optimizer.php
+++ b/Library/Optimizers/FunctionCall/Md5Optimizer.php
@@ -59,14 +59,14 @@ class Md5Optimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_md5(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/MicrotimeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/MicrotimeOptimizer.php
@@ -56,19 +56,21 @@ class MicrotimeOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/time');
         
 
         if (!isset($expression['parameters'])) {
             $symbolVariable->setDynamicTypes('string');
+            if ($call->mustInitSymbolVariable()) {
+                $symbolVariable->initVariant($context);
+            }
             $context->codePrinter->output('zephir_microtime(' . $symbolVariable->getName() . ', NULL TSRMLS_CC);');
         } else {
             $symbolVariable->setDynamicTypes('double');
             $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+            if ($call->mustInitSymbolVariable()) {
+                $symbolVariable->initVariant($context);
+            }
             $context->codePrinter->output('zephir_microtime(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         }
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);

--- a/Library/Optimizers/FunctionCall/PowOptimizer.php
+++ b/Library/Optimizers/FunctionCall/PowOptimizer.php
@@ -59,14 +59,13 @@ class PowOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
+        $context->headersManager->add('kernel/math');
+        $symbolVariable->setDynamicTypes('variable');
+        $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        
         if ($call->mustInitSymbolVariable()) {
             $symbolVariable->initVariant($context);
         }
-
-        $context->headersManager->add('kernel/math');
-        $symbolVariable->setDynamicTypes('variable');
-
-        $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
         $context->codePrinter->output('zephir_pow_function(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/PregMatchOptimizer.php
+++ b/Library/Optimizers/FunctionCall/PregMatchOptimizer.php
@@ -95,9 +95,6 @@ class PregMatchOptimizer extends OptimizerAbstract
         if (!$symbolVariable->isVariable()) {
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
 
         $context->headersManager->add('kernel/string');
 
@@ -120,6 +117,9 @@ class PregMatchOptimizer extends OptimizerAbstract
             $offset = '0 ';
         }
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_preg_match(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ', ' . $matchesVariable->getName() . ', ' . $this::GLOBAL_MATCH . ', ' . $flags . ', ' . $offset . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/PrepareVirtualPathOptimizer.php
+++ b/Library/Optimizers/FunctionCall/PrepareVirtualPathOptimizer.php
@@ -62,12 +62,11 @@ class PrepareVirtualPathOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
+        $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+
         if ($call->mustInitSymbolVariable()) {
             $symbolVariable->initVariant($context);
         }
-
-        $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
-
         $context->codePrinter->output('zephir_prepare_virtual_path(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/RoundOptimizer.php
+++ b/Library/Optimizers/FunctionCall/RoundOptimizer.php
@@ -60,13 +60,13 @@ class RoundOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/math');
         $symbolVariable->setDynamicTypes('double');
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
 
         switch (count($expression['parameters'])) {
             /**

--- a/Library/Optimizers/FunctionCall/StrReplaceOptimizer.php
+++ b/Library/Optimizers/FunctionCall/StrReplaceOptimizer.php
@@ -62,15 +62,15 @@ class StrReplaceOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
 
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_fast_str_replace(&' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ', ' . $resolvedParams[2] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/StripcslashesOptimizer.php
+++ b/Library/Optimizers/FunctionCall/StripcslashesOptimizer.php
@@ -60,16 +60,15 @@ class StripcslashesOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
 
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_stripcslashes(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/StripslashesOptimizer.php
+++ b/Library/Optimizers/FunctionCall/StripslashesOptimizer.php
@@ -60,16 +60,14 @@ class StripslashesOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
-
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_stripslashes(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/StrposOptimizer.php
+++ b/Library/Optimizers/FunctionCall/StrposOptimizer.php
@@ -74,14 +74,12 @@ class StrposOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
+        $context->headersManager->add('kernel/string');
+        $symbolVariable->setDynamicTypes('int');
+
         if ($call->mustInitSymbolVariable()) {
             $symbolVariable->initVariant($context);
         }
-
-        $context->headersManager->add('kernel/string');
-
-        $symbolVariable->setDynamicTypes('int');
-
         $context->codePrinter->output('zephir_fast_strpos(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ', ' . $offset .');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/StrtolowerOptimizer.php
+++ b/Library/Optimizers/FunctionCall/StrtolowerOptimizer.php
@@ -59,14 +59,14 @@ class StrtolowerOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_fast_strtolower(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/StrtoupperOptimizer.php
+++ b/Library/Optimizers/FunctionCall/StrtoupperOptimizer.php
@@ -59,14 +59,14 @@ class StrtoupperOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_fast_strtoupper(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/SubstrOptimizer.php
+++ b/Library/Optimizers/FunctionCall/SubstrOptimizer.php
@@ -86,14 +86,13 @@ class SubstrOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
 
         $symbolVariable->setDynamicTypes('string');
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_substr(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $params[0] . ', ' . $params[1] .', ' . $flags .');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/TimeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/TimeOptimizer.php
@@ -55,13 +55,12 @@ class TimeOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/time');
         $symbolVariable->setDynamicTypes('long');
 
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_time(' . $symbolVariable->getName() . ');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/TrimOptimizer.php
+++ b/Library/Optimizers/FunctionCall/TrimOptimizer.php
@@ -66,10 +66,6 @@ class TrimOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
 
         $symbolVariable->setDynamicTypes('string');
@@ -79,7 +75,9 @@ class TrimOptimizer extends OptimizerAbstract
         if (isset($resolvedParams[1])) {
             $charlist = $resolvedParams[1];
         }
-
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_fast_trim(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $charlist . ', ' . static::$TRIM_WHERE . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/UcfirstOptimizer.php
+++ b/Library/Optimizers/FunctionCall/UcfirstOptimizer.php
@@ -59,14 +59,13 @@ class UcfirstOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_ucfirst(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/UncamelizeOptimizer.php
+++ b/Library/Optimizers/FunctionCall/UncamelizeOptimizer.php
@@ -59,15 +59,14 @@ class UncamelizeOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
 
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_uncamelize(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ');');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/UniqueKeyOptimizer.php
+++ b/Library/Optimizers/FunctionCall/UniqueKeyOptimizer.php
@@ -59,15 +59,14 @@ class UniqueKeyOptimizer extends OptimizerAbstract
             throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
         }
 
-        if ($call->mustInitSymbolVariable()) {
-            $symbolVariable->initVariant($context);
-        }
-
         $context->headersManager->add('kernel/string');
 
         $symbolVariable->setDynamicTypes('string');
 
         $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
         $context->codePrinter->output('zephir_unique_key(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
         return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
     }

--- a/Library/Optimizers/FunctionCall/VarExportOptimizer.php
+++ b/Library/Optimizers/FunctionCall/VarExportOptimizer.php
@@ -58,9 +58,6 @@ class VarExportOptimizer extends OptimizerAbstract
             if (!$symbolVariable->isVariable()) {
                 throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
             }
-            if ($call->mustInitSymbolVariable()) {
-                $symbolVariable->initVariant($context);
-            }
         }
 
         $context->headersManager->add('kernel/variables');
@@ -115,6 +112,9 @@ class VarExportOptimizer extends OptimizerAbstract
          * let a = var_export(val);
          */
         if ($symbolVariable) {
+            if ($call->mustInitSymbolVariable()) {
+                $symbolVariable->initVariant($context);
+            }
             $context->codePrinter->output('zephir_var_export_ex(' . $symbolVariable->getName() . ', &(' . $variable->getName() . ') TSRMLS_CC);');
             return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
         }


### PR DESCRIPTION
Small example: (pseudo-code)
``
let val = OPTIMIZED_FUNC(val);
``
can result in
```
ZEPHIR_INIT_NVAR(_1); //NOTICE that here the previous value of _1 get's destroyed
ZVAL_DOUBLE(val, OPTIMIZED_FUNC_C(zephir_get_numberval(_1)));
```

Behavior can be that the result is simply 0, since zephir_get_numberval receives
an "empty" zval.
Therefor the best approach is to delay the initVariant atleast until the code
for parameter resolving has been generated.
