### PR TITLE
Improve api generation

### DIFF
--- a/Library/CommandArgumentParser.php
+++ b/Library/CommandArgumentParser.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ +----------------------------------------------------------------------+
+ | Zephir Language                                                      |
+ +----------------------------------------------------------------------+
+ | Copyright (c) 2013-2015 Zephir Team                                  |
+ +----------------------------------------------------------------------+
+ | This source file is subject to version 1.0 of the MIT license,       |
+ | that is bundled with this package in the file LICENSE, and is        |
+ | available through the world-wide-web at the following url:           |
+ | http://www.zephir-lang.com/license                                   |
+ |                                                                      |
+ | If you did not receive a copy of the MIT license and are unable      |
+ | to obtain it through the world-wide-web, please send a note to       |
+ | license@zephir-lang.com so we can mail you a copy immediately.       |
+ +----------------------------------------------------------------------+
+*/
+
+namespace Zephir;
+
+/**
+ * @author              Patrick Fisher <patrick@pwfisher.com>
+ * @since               August 21, 2009
+ * @see                 https://github.com/pwfisher/CommandLine.php
+ */
+class CommandArgumentParser {
+    public static $args;
+
+    /**
+     * PARSE ARGUMENTS
+     *
+     * This command line option parser supports any combination of three types of options
+     * [single character options (`-a -b` or `-ab` or `-c -d=dog` or `-cd dog`),
+     * long options (`--foo` or `--bar=baz` or `--bar baz`)
+     * and arguments (`arg1 arg2`)] and returns a simple array.
+     *
+     * [pfisher ~]$ php test.php --foo --bar=baz --spam eggs
+     *   ["foo"]   => true
+     *   ["bar"]   => "baz"
+     *   ["spam"]  => "eggs"
+     *
+     * [pfisher ~]$ php test.php -abc foo
+     *   ["a"]     => true
+     *   ["b"]     => true
+     *   ["c"]     => "foo"
+     *
+     * [pfisher ~]$ php test.php arg1 arg2 arg3
+     *   [0]       => "arg1"
+     *   [1]       => "arg2"
+     *   [2]       => "arg3"
+     *
+     * [pfisher ~]$ php test.php plain-arg --foo --bar=baz --funny="spam=eggs" --also-funny=spam=eggs \
+     * > 'plain arg 2' -abc -k=value "plain arg 3" --s="original" --s='overwrite' --s
+     *   [0]       => "plain-arg"
+     *   ["foo"]   => true
+     *   ["bar"]   => "baz"
+     *   ["funny"] => "spam=eggs"
+     *   ["also-funny"]=> "spam=eggs"
+     *   [1]       => "plain arg 2"
+     *   ["a"]     => true
+     *   ["b"]     => true
+     *   ["c"]     => true
+     *   ["k"]     => "value"
+     *   [2]       => "plain arg 3"
+     *   ["s"]     => "overwrite"
+     *
+     * Not supported: `-cd=dog`.
+     *
+     * @author              Patrick Fisher <patrick@pwfisher.com>
+     * @since               August 21, 2009
+     * @see                 https://github.com/pwfisher/CommandLine.php
+     * @see                 http://www.php.net/manual/en/features.commandline.php
+     *                      #81042 function arguments($argv) by technorati at gmail dot com, 12-Feb-2008
+     *                      #78651 function getArgs($args) by B Crawford, 22-Oct-2007
+     * @usage               $args = CommandLine::parseArgs($_SERVER['argv']);
+     */
+    public static function parseArgs($argv = null)
+    {
+        $argv                           = $argv ? $argv : $_SERVER['argv'];
+
+        array_shift($argv);
+        $out                            = array();
+
+        for ($i = 0, $j = count($argv); $i < $j; $i++)
+        {
+            $arg                        = $argv[$i];
+
+            // --foo --bar=baz
+            if (substr($arg, 0, 2) === '--')
+            {
+                $eqPos                  = strpos($arg, '=');
+
+                // --foo
+                if ($eqPos === false)
+                {
+                    $key                = substr($arg, 2);
+
+                    // --foo value
+                    if ($i + 1 < $j && $argv[$i + 1][0] !== '-')
+                    {
+                        $value          = $argv[$i + 1];
+                        $i++;
+                    }
+                    else
+                    {
+                        $value          = isset($out[$key]) ? $out[$key] : true;
+                    }
+                    $out[$key]          = $value;
+                }
+
+                // --bar=baz
+                else
+                {
+                    $key                = substr($arg, 2, $eqPos - 2);
+                    $value              = substr($arg, $eqPos + 1);
+                    $out[$key]          = $value;
+                }
+            }
+
+            // -k=value -abc
+            else if (substr($arg, 0, 1) === '-')
+            {
+                // -k=value
+                if (substr($arg, 2, 1) === '=')
+                {
+                    $key                = substr($arg, 1, 1);
+                    $value              = substr($arg, 3);
+                    $out[$key]          = $value;
+                }
+                // -abc
+                else
+                {
+                    $chars              = str_split(substr($arg, 1));
+                    foreach ($chars as $char)
+                    {
+                        $key            = $char;
+                        $value          = isset($out[$key]) ? $out[$key] : true;
+                        $out[$key]      = $value;
+                    }
+                    // -a value1 -abc value2
+                    if ($i + 1 < $j && $argv[$i + 1][0] !== '-')
+                    {
+                        $out[$key]      = $argv[$i + 1];
+                        $i++;
+                    }
+                }
+            }
+
+            // plain-arg
+            else
+            {
+                $value                  = $arg;
+                $out[]                  = $value;
+            }
+        }
+
+        self::$args                     = $out;
+
+        return $out;
+    }
+
+    /**
+     * GET BOOLEAN
+     */
+    public static function getBoolean($key, $default = false)
+    {
+        if (!isset(self::$args[$key]))
+        {
+            return $default;
+        }
+        $value                          = self::$args[$key];
+
+        if (is_bool($value))
+        {
+            return $value;
+        }
+
+        if (is_int($value))
+        {
+            return (bool)$value;
+        }
+
+        if (is_string($value))
+        {
+            $value                      = strtolower($value);
+            $map = array(
+                'y'                     => true,
+                'n'                     => false,
+                'yes'                   => true,
+                'no'                    => false,
+                'true'                  => true,
+                'false'                 => false,
+                '1'                     => true,
+                '0'                     => false,
+                'on'                    => true,
+                'off'                   => false,
+            );
+            if (isset($map[$value]))
+            {
+                return $map[$value];
+            }
+        }
+
+        return $default;
+    }
+}

--- a/Library/CommandArgumentParser.php
+++ b/Library/CommandArgumentParser.php
@@ -24,7 +24,8 @@ namespace Zephir;
  * @since               August 21, 2009
  * @see                 https://github.com/pwfisher/CommandLine.php
  */
-class CommandArgumentParser {
+class CommandArgumentParser
+{
     public static $args;
 
     /**
@@ -82,74 +83,50 @@ class CommandArgumentParser {
         array_shift($argv);
         $out                            = array();
 
-        for ($i = 0, $j = count($argv); $i < $j; $i++)
-        {
+        for ($i = 0, $j = count($argv); $i < $j; $i++) {
             $arg                        = $argv[$i];
 
             // --foo --bar=baz
-            if (substr($arg, 0, 2) === '--')
-            {
+            if (substr($arg, 0, 2) === '--') {
                 $eqPos                  = strpos($arg, '=');
 
                 // --foo
-                if ($eqPos === false)
-                {
+                if ($eqPos === false) {
                     $key                = substr($arg, 2);
 
                     // --foo value
-                    if ($i + 1 < $j && $argv[$i + 1][0] !== '-')
-                    {
+                    if ($i + 1 < $j && $argv[$i + 1][0] !== '-') {
                         $value          = $argv[$i + 1];
                         $i++;
-                    }
-                    else
-                    {
+                    } else {
                         $value          = isset($out[$key]) ? $out[$key] : true;
                     }
                     $out[$key]          = $value;
-                }
-
-                // --bar=baz
-                else
-                {
+                } else { // --bar=baz
                     $key                = substr($arg, 2, $eqPos - 2);
                     $value              = substr($arg, $eqPos + 1);
                     $out[$key]          = $value;
                 }
-            }
-
-            // -k=value -abc
-            else if (substr($arg, 0, 1) === '-')
-            {
+            } else if (substr($arg, 0, 1) === '-') { // -k=value -abc
                 // -k=value
-                if (substr($arg, 2, 1) === '=')
-                {
+                if (substr($arg, 2, 1) === '=') {
                     $key                = substr($arg, 1, 1);
                     $value              = substr($arg, 3);
                     $out[$key]          = $value;
-                }
-                // -abc
-                else
-                {
+                } else { // -abc
                     $chars              = str_split(substr($arg, 1));
-                    foreach ($chars as $char)
-                    {
+                    foreach ($chars as $char) {
                         $key            = $char;
                         $value          = isset($out[$key]) ? $out[$key] : true;
                         $out[$key]      = $value;
                     }
                     // -a value1 -abc value2
-                    if ($i + 1 < $j && $argv[$i + 1][0] !== '-')
-                    {
+                    if ($i + 1 < $j && $argv[$i + 1][0] !== '-') {
                         $out[$key]      = $argv[$i + 1];
                         $i++;
                     }
                 }
-            }
-
-            // plain-arg
-            else
-            {
+            } else { // plain-arg
                 $value                  = $arg;
                 $out[]                  = $value;
             }
@@ -165,24 +142,20 @@ class CommandArgumentParser {
      */
     public static function getBoolean($key, $default = false)
     {
-        if (!isset(self::$args[$key]))
-        {
+        if (!isset(self::$args[$key])) {
             return $default;
         }
         $value                          = self::$args[$key];
 
-        if (is_bool($value))
-        {
+        if (is_bool($value)) {
             return $value;
         }
 
-        if (is_int($value))
-        {
+        if (is_int($value)) {
             return (bool)$value;
         }
 
-        if (is_string($value))
-        {
+        if (is_string($value)) {
             $value                      = strtolower($value);
             $map = array(
                 'y'                     => true,
@@ -196,8 +169,7 @@ class CommandArgumentParser {
                 'on'                    => true,
                 'off'                   => false,
             );
-            if (isset($map[$value]))
-            {
+            if (isset($map[$value])) {
                 return $map[$value];
             }
         }

--- a/Library/Commands/CommandAbstract.php
+++ b/Library/Commands/CommandAbstract.php
@@ -65,17 +65,18 @@ abstract class CommandAbstract implements CommandInterface
      * Parse the input arguments for the command and returns theme as an associative array
      * @return array the list of the parameters
      */
-    public function parseArguments(){
+    public function parseArguments()
+    {
 
         if (isset($_SERVER['argv'][2])) {
             $this->setParameter('namespace', strtolower(preg_replace('/[^0-9a-zA-Z]/', '', $_SERVER['argv'][2])));
         }
 
-        if(count($_SERVER['argv']) > 2){
-            $commandArgs = array_slice($_SERVER['argv'],2);
+        if (count($_SERVER['argv']) > 2) {
+            $commandArgs = array_slice($_SERVER['argv'], 2);
             $parser = new CommandArgumentParser();
-            $params = $parser->parseArgs(array_merge(["command"],$commandArgs));
-        }else{
+            $params = $parser->parseArgs(array_merge(["command"], $commandArgs));
+        } else {
             $params = [];
         }
 

--- a/Library/Commands/CommandAbstract.php
+++ b/Library/Commands/CommandAbstract.php
@@ -68,10 +68,6 @@ abstract class CommandAbstract implements CommandInterface
     public function parseArguments()
     {
 
-        if (isset($_SERVER['argv'][2])) {
-            $this->setParameter('namespace', strtolower(preg_replace('/[^0-9a-zA-Z]/', '', $_SERVER['argv'][2])));
-        }
-
         if (count($_SERVER['argv']) > 2) {
             $commandArgs = array_slice($_SERVER['argv'], 2);
             $parser = new CommandArgumentParser();

--- a/Library/Commands/CommandAbstract.php
+++ b/Library/Commands/CommandAbstract.php
@@ -73,7 +73,7 @@ abstract class CommandAbstract implements CommandInterface
             $parser = new CommandArgumentParser();
             $params = $parser->parseArgs(array_merge(array("command"), $commandArgs));
         } else {
-            $params = [];
+            $params = array();
         }
 
         return $params;

--- a/Library/Commands/CommandAbstract.php
+++ b/Library/Commands/CommandAbstract.php
@@ -19,6 +19,7 @@
 
 namespace Zephir\Commands;
 
+use Zephir\CommandArgumentParser;
 use Zephir\Config;
 use Zephir\Logger;
 use Zephir\Compiler;
@@ -57,6 +58,29 @@ abstract class CommandAbstract implements CommandInterface
     public function getParameter($name)
     {
         return (isset($this->_parameters[$name])) ? $this->_parameters[$name] : null;
+    }
+
+
+    /**
+     * Parse the input arguments for the command and returns theme as an associative array
+     * @return array the list of the parameters
+     */
+    public function parseArguments(){
+
+        if (isset($_SERVER['argv'][2])) {
+            $this->setParameter('namespace', strtolower(preg_replace('/[^0-9a-zA-Z]/', '', $_SERVER['argv'][2])));
+        }
+
+        if(count($_SERVER['argv']) > 2){
+            $commandArgs = array_slice($_SERVER['argv'],2);
+            $parser = new CommandArgumentParser();
+            $params = $parser->parseArgs(array_merge(["command"],$commandArgs));
+        }else{
+            $params = [];
+        }
+
+        return $params;
+
     }
 
     /**

--- a/Library/Commands/CommandAbstract.php
+++ b/Library/Commands/CommandAbstract.php
@@ -71,7 +71,7 @@ abstract class CommandAbstract implements CommandInterface
         if (count($_SERVER['argv']) > 2) {
             $commandArgs = array_slice($_SERVER['argv'], 2);
             $parser = new CommandArgumentParser();
-            $params = $parser->parseArgs(array_merge(["command"], $commandArgs));
+            $params = $parser->parseArgs(array_merge(array("command"), $commandArgs));
         } else {
             $params = [];
         }

--- a/Library/Commands/CommandApi.php
+++ b/Library/Commands/CommandApi.php
@@ -65,7 +65,7 @@ class CommandApi extends CommandAbstract
 
         $params = $this->parseArguments();
 
-        $allowedArgs = ["theme-path" => "@.+@"];
+        $allowedArgs = array("theme-path" => "@.+@");
 
         foreach ($params as $k => $p) {
             if (isset($allowedArgs[$k])) {

--- a/Library/Commands/CommandApi.php
+++ b/Library/Commands/CommandApi.php
@@ -67,12 +67,10 @@ class CommandApi extends CommandAbstract
 
         $allowedArgs = ["theme-path" => "@.+@"];
 
-        foreach($params as $k=>$p){
-
+        foreach ($params as $k => $p) {
             if (isset($allowedArgs[$k])) {
-
                 if (preg_match($allowedArgs[$k], $p)) {
-                    $this->setParameter($k,$p);
+                    $this->setParameter($k, $p);
                 } else {
                     throw new Exception("Invalid value for argument '$k'");
                 }

--- a/Library/Commands/CommandApi.php
+++ b/Library/Commands/CommandApi.php
@@ -19,6 +19,10 @@
 
 namespace Zephir\Commands;
 
+use Zephir\Config;
+use Zephir\Exception;
+use Zephir\Logger;
+
 /**
  * CommandApi
  *
@@ -43,7 +47,7 @@ class CommandApi extends CommandAbstract
      */
     public function getUsage()
     {
-        return 'api';
+        return 'api [--theme-path=/path]';
     }
 
     /**
@@ -54,5 +58,30 @@ class CommandApi extends CommandAbstract
     public function getDescription()
     {
         return 'Generates a HTML API';
+    }
+
+    public function execute(Config $config, Logger $logger)
+    {
+
+        $params = $this->parseArguments();
+
+        $allowedArgs = ["theme-path" => "@.+@"];
+
+        foreach($params as $k=>$p){
+
+            if (isset($allowedArgs[$k])) {
+
+                if (preg_match($allowedArgs[$k], $p)) {
+                    $this->setParameter($k,$p);
+                } else {
+                    throw new Exception("Invalid value for argument '$k'");
+                }
+
+            } else {
+                throw new Exception("Invalid argument '$k''");
+            }
+        }
+
+        parent::execute($config, $logger);
     }
 }

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -970,7 +970,7 @@ class Compiler
 
         $this->logger->output('Generating API...');
 
-        $documentator = new Documentation($this->files, $this->config, $this->logger);
+        $documentator = new Documentation($this->files, $this->config, $this->logger, $command);
         $documentator->build();
     }
 

--- a/Library/Documentation.php
+++ b/Library/Documentation.php
@@ -63,14 +63,13 @@ class Documentation
         $this->logger  = $logger;
 
         $themeConfig = $config->get("theme", "api");
-        $themeConfig["options"]["version"] = $config->get('version');
 
         if (!$themeConfig) {
             throw new ConfigException("Theme configuration is not present");
         }
 
         if (!isset($themeConfig["name"]) || !$themeConfig["name"]) {
-            throw new ConfigException("There is no theme ");
+            throw new ConfigException("There is no theme");
         }
 
         $themeDir = realpath(ZEPHIRPATH . "/templates/Api/themes/" . $themeConfig["name"]);
@@ -96,7 +95,7 @@ class Documentation
             throw new Exception("Can't write output directory $outputDir");
         }
 
-        $this->theme = new Theme($themeDir, $outputDir, $themeConfig);
+        $this->theme = new Theme($themeDir, $outputDir, $themeConfig, $config);
     }
 
     public function build()

--- a/Library/Documentation.php
+++ b/Library/Documentation.php
@@ -109,14 +109,15 @@ class Documentation
         $this->theme = new Theme($themeDir, $outputDir, $themeConfig, $config);
     }
 
-    private function __findThemeDirectory($themeConfig, Config $config, CommandInterface $command){
+    private function __findThemeDirectory($themeConfig, Config $config, CommandInterface $command)
+    {
 
         // check if the path was set from the command
         $themePath = $command->getParameter("theme-path");
-        if(null!==$themePath){
-            if(file_exists($themePath) && is_dir($themePath)){
+        if (null!==$themePath) {
+            if (file_exists($themePath) && is_dir($themePath)) {
                 return $themePath;
-            }else{
+            } else {
                 throw new Exception("Invalid value for option 'theme-path' : the theme '$themePath' was not found or is not a valid theme.");
             }
         }
@@ -125,24 +126,24 @@ class Documentation
         // check the theme from the config
 
         // check if there are additional theme paths in the config
-        $themeDirectoriesConfig = $config->get("theme-directories","api");
-        if($themeDirectoriesConfig){
-            if(is_array($themeDirectoriesConfig)){
+        $themeDirectoriesConfig = $config->get("theme-directories", "api");
+        if ($themeDirectoriesConfig) {
+            if (is_array($themeDirectoriesConfig)) {
                 $themesDirectories = $themeDirectoriesConfig;
-            }else{
+            } else {
                 throw new ConfigException("invalid value for theme config 'theme-directories'");
             }
-        }else{
+        } else {
             $themesDirectories = [];
         }
         $themesDirectories[] = ZEPHIRPATH . "templates/Api/themes";
 
         $path = null;
 
-        foreach($themesDirectories as $themeDir){
-            $dir = rtrim($themeDir,"/") . "/";
+        foreach ($themesDirectories as $themeDir) {
+            $dir = rtrim($themeDir, "/") . "/";
             $path = realpath($dir . $themeConfig["name"]);
-            if($path){
+            if ($path) {
                 break;
             }
         }

--- a/Library/Documentation.php
+++ b/Library/Documentation.php
@@ -109,6 +109,22 @@ class Documentation
         $this->theme = new Theme($themeDir, $outputDir, $themeConfig, $config);
     }
 
+    /**
+     * Find the theme directory depending on the command  line options and the config.
+     *
+     * theme directory is checked in this order :
+     *  => check if the command line argument --theme-path was given
+     *  => if not ; find the different theme directories on the config $config['api']['theme-directories']
+     *  search the theme from the name ($config['api']['theme']['name'] in the theme directories,
+     * if nothing was found, we look in the zephir install dir default themes (templates/Api/themes)
+     *
+     * @param $themeConfig
+     * @param Config $config
+     * @param CommandInterface $command
+     * @return null|string
+     * @throws ConfigException
+     * @throws Exception
+     */
     private function __findThemeDirectory($themeConfig, Config $config, CommandInterface $command)
     {
 

--- a/Library/Documentation.php
+++ b/Library/Documentation.php
@@ -150,7 +150,7 @@ class Documentation
                 throw new ConfigException("invalid value for theme config 'theme-directories'");
             }
         } else {
-            $themesDirectories = [];
+            $themesDirectories = array();
         }
         $themesDirectories[] = ZEPHIRPATH . "templates/Api/themes";
 

--- a/Library/Documentation/Template.php
+++ b/Library/Documentation/Template.php
@@ -46,9 +46,9 @@ class Template
     public function projectConfig($name)
     {
 
-        if(isset($this->projectConfig)){
+        if (isset($this->projectConfig)) {
             return $this->projectConfig->get($name);
-        }else{
+        } else {
             return null;
         }
 
@@ -67,7 +67,8 @@ class Template
      * set the config of the project (it usually wraps the version, the theme config, etc...)
      * @param array $projectConfig
      */
-    public function setProjectConfig($projectConfig){
+    public function setProjectConfig($projectConfig)
+    {
         $this->projectConfig = $projectConfig;
     }
 

--- a/Library/Documentation/Template.php
+++ b/Library/Documentation/Template.php
@@ -2,6 +2,7 @@
 
 namespace Zephir\Documentation;
 
+use Zephir\Config;
 use Zephir\Exception;
 use Zephir\CompilerFile;
 use Zephir\ClassDefinition;
@@ -16,6 +17,10 @@ class Template
     protected $nestedLevel;
     protected $pathToRoot = "./";
     protected $themeOptions;
+    /**
+     * @var Config
+     */
+    protected $projectConfig;
 
     public function __construct($data, $rootDirectory, $template, $nestedLevel = 0)
     {
@@ -34,14 +39,41 @@ class Template
         $this->nestedLevel = $nestedLevel;
     }
 
+    /**
+     * find the value in the project configuration (e.g the version)
+     * @param string $name the name of the config to get
+     */
+    public function projectConfig($name)
+    {
+
+        if(isset($this->projectConfig)){
+            return $this->projectConfig->get($name);
+        }else{
+            return null;
+        }
+
+    }
+
+    /**
+     * find the value of an option of the theme
+     * @param string $name the name of the option to get
+     */
     public function themeOption($name)
     {
         return isset($this->themeOptions[$name]) ? $this->themeOptions[$name] : null ;
     }
 
     /**
+     * set the config of the project (it usually wraps the version, the theme config, etc...)
+     * @param array $projectConfig
+     */
+    public function setProjectConfig($projectConfig){
+        $this->projectConfig = $projectConfig;
+    }
+
+    /**
      * add theme options to make them available during the render phase
-     * @param type $themeOptions
+     * @param array $themeOptions
      */
     public function setThemeOptions($themeOptions)
     {
@@ -132,6 +164,7 @@ class Template
         $template = new Template(array_merge($this->data, $data), $this->rootDirectory, $fileName, $newLevel);
         $template->setPathToRoot($this->getPathToRoot());
         $template->setThemeOptions($this->themeOptions);
+        $template->setProjectConfig($this->projectConfig);
 
         return $template->parse();
     }

--- a/Library/Documentation/Theme.php
+++ b/Library/Documentation/Theme.php
@@ -29,13 +29,15 @@ class Theme
     protected $outputDir;
     protected $themeConfig;
     protected $options;
+    protected $projectConfig;
 
-    public function __construct($themeDir, $outputDir, $themeConfig)
+    public function __construct($themeDir, $outputDir, $themeConfig, $config)
     {
         $this->outputDir   = $outputDir;
         $this->themeConfig = $themeConfig;
         $this->themeDir    = $themeDir;
         $this->options     = $themeConfig["options"];
+        $this->projectConfig= $config;
     }
 
 
@@ -64,6 +66,8 @@ class Theme
         $template = new Template($file->getData(), $this->themeDir, $file->getTemplateName());
         $template->setPathToRoot($pathToRoot);
         $template->setThemeOptions($this->options);
+        $template->setProjectConfig($this->projectConfig);
+
 
         touch($outputFilename);
         $template->write($outputFilename);

--- a/templates/Api/themes/zephir/layout/layout.phtml
+++ b/templates/Api/themes/zephir/layout/layout.phtml
@@ -37,7 +37,11 @@
     <body onload="prettyPrint()">
         <div id="top-bar">
             <div id="top-left">
-                Zephir Documentation <span class="version">v<?php echo $this->projectConfig('version'); ?></span>
+                <?php if ($this->themeOption("title")){ ?>
+                    <?= str_replace( array("%_name_%", "%_version_%") , array($this->projectConfig("name"), $this->projectConfig('version')) , $this->themeOption("title")) ?>
+                <?php }else{ ?>
+                    <?= $this->projectConfig("name") ?> Documentation <span class="version">v<?php echo $this->projectConfig('version'); ?></span>
+                <?php } ?>
             </div>
             <div id="top-right">
 

--- a/templates/Api/themes/zephir/layout/layout.phtml
+++ b/templates/Api/themes/zephir/layout/layout.phtml
@@ -37,7 +37,7 @@
     <body onload="prettyPrint()">
         <div id="top-bar">
             <div id="top-left">
-                Zephir Documentation <span class="version">v<?php echo $this->themeOption('version'); ?></span>
+                Zephir Documentation <span class="version">v<?php echo $this->projectConfig('version'); ?></span>
             </div>
             <div id="top-right">
 


### PR DESCRIPTION
In this PR i added some stuff i needed for the phalcon 2 api generation : 

- a command line argument parser (copyed from  https://github.com/pwfisher/CommandLine.php)
- a fix for the way the version was got in the default api theme, additionally we now have access to the config from a template
- 2 ways to get a theme : 
  - from the command line ``zephir api theme-path=/path-to-theme``
  - from the config by adding theme directories (``$config["api"]["theme-directories"]``)

I'll try to add the documentation asap.

Let me know if something is wrong