### PR TITLE
Fix #537: Make sure class properties are initialized in the right order

### DIFF
--- a/test/properties/extendspublicproperties.zep
+++ b/test/properties/extendspublicproperties.zep
@@ -4,4 +4,6 @@ namespace Test\Properties;
 class ExtendsPublicProperties extends PublicProperties
 {
 	public testPropertyFromClassNameConstantValue = PublicProperties::TEST_CONST;
+
+	protected someGetterSetterArray = ["holy"];
 }

--- a/test/properties/publicproperties.zep
+++ b/test/properties/publicproperties.zep
@@ -67,6 +67,8 @@ class PublicProperties
 		"danger": ["class": "alert alert-danger"]
 	];
 
+	protected someGetterSetterArray = [] { set, get };
+
 	public testPropertyFromSelfConstantValue = self::TEST_CONST;
 
 	public testPropertyFromClassNameConstantValue = PublicProperties::TEST_CONST;

--- a/unit-tests/Extension/Properties/PublicPropertiesTest.php
+++ b/unit-tests/Extension/Properties/PublicPropertiesTest.php
@@ -20,6 +20,7 @@
 namespace Extension\Properties;
 
 use Test\Properties\PublicProperties;
+use Test\Properties\ExtendsPublicProperties;
 
 class PublicPropertiesTest extends \PHPUnit_Framework_TestCase
 {
@@ -43,5 +44,14 @@ class PublicPropertiesTest extends \PHPUnit_Framework_TestCase
     {
         $t = new PublicProperties();
         $this->assertTrue($t->test394Issue());
+    }
+    
+    /**
+     * @link https://github.com/phalcon/zephir/issues/537
+     */
+    public function test537Issue()
+    {
+        $t = new ExtendsPublicProperties();
+        $this->assertEquals($t->getSomeGetterSetterArray(), array("holy"));
     }
 }


### PR DESCRIPTION
Testcase from #537 adopted.

Previously the constructor code of the parent class was appended,
because the parents constructor method was simply reused.
This explicitly prepends only the statements.
