### PR TITLE
Fix #665: Ensure that the ternary operator promotes temporary variables

### DIFF
--- a/Library/Operators/Other/TernaryOperator.php
+++ b/Library/Operators/Other/TernaryOperator.php
@@ -44,9 +44,12 @@ class TernaryOperator extends BaseOperator
     public function compile($expression, CompilationContext $compilationContext)
     {
         /**
-         * This variable is used to check if the compound and expression is evaluated as true or false
+         * This variable is used to check if the compound and expression is evaluated as true or false:
+         * Ensure that newly allocated variables are local-only (setReadOnly)
          */
+        $this->setReadOnly(false);
         $returnVariable = $this->getExpected($compilationContext, $expression, false);
+        /* Make sure that passed variables (passed symbol variables) are promoted */
         $returnVariable->setLocalOnly(false);
 
         if ($returnVariable->getType() != 'variable' || $returnVariable->getName() == 'return_value') {

--- a/test/ternary.zep
+++ b/test/ternary.zep
@@ -32,6 +32,20 @@ class Ternary
 		//return gettype(typeof a == "resource" ? "unknown": false);
 	}
 
+	/**
+	 * @link https://github.com/phalcon/zephir/issues/665
+	 */
+	public function testTernaryWithPromotedTemporaryVariable()
+	{
+		var var2, var3;
+
+		let var2 = ["_b_","_c_"];
+
+		let var3 = explode("_", isset(var2[1]) ? var2[1] : "");
+
+		return var3;
+	}
+
     /**
      * @link https://github.com/phalcon/zephir/issues/297
      */

--- a/unit-tests/Extension/TernaryTest.php
+++ b/unit-tests/Extension/TernaryTest.php
@@ -28,6 +28,7 @@ class TernaryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $t->testTernary2(true));
         $this->assertEquals('bar', $t->testTernary2(false));
         $this->assertEquals(3, $t->testTernaryAfterLetVariable());
+        $this->assertEquals(array('', 'c', ''), $t->testTernaryWithPromotedTemporaryVariable());
     }
 
     /*public function testComplex()


### PR DESCRIPTION
Fix the edge-case when the ternary operator creates a new temporary variable
(via getExpected), which was allowed to be local.
The variable was promoted in the following, leading to wrong initialization code
being created before.