### PR TITLE
Allow to append custom C classes to extension

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -866,9 +866,9 @@ class Compiler
         /**
          * Round 3.4. Load extra classes sources
          */
-        $extraClasses = $this->config->get('extra-classes');  
+        $extraClasses = $this->config->get('extra-classes');
         if (is_array($extraClasses)) {
-            foreach($extraClasses as $value) {
+            foreach ($extraClasses as $value) {
                 if (isset($value['source'])) {
                     $this->extraFiles[] = $value['source'];
                 }
@@ -1735,9 +1735,9 @@ class Compiler
         /**
          * Append extra details
          */
-        $extraClasses = $this->config->get('extra-classes');  
+        $extraClasses = $this->config->get('extra-classes');
         if (is_array($extraClasses)) {
-            foreach($extraClasses as $key=>$value) {
+            foreach ($extraClasses as $key=>$value) {
                 if (isset($value['init'])) {
                     $completeClassInits[] = "ZEPHIR_INIT(".$value['init'].")";
                 }
@@ -1793,9 +1793,9 @@ class Compiler
         /**
          * Append extra headers
          */
-        $extraClasses = $this->config->get('extra-classes');  
+        $extraClasses = $this->config->get('extra-classes');
         if (is_array($extraClasses)) {
-            foreach($extraClasses as $value) {
+            foreach ($extraClasses as $value) {
                 if (isset($value['header'])) {
                     $include = '#include "' . $value['header'] . '"';
                     $includeHeaders[] = $include;

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -864,6 +864,18 @@ class Compiler
         }
 
         /**
+         * Round 3.4. Load extra classes sources
+         */
+        $extraClasses = $this->config->get('extra-classes');  
+        if (is_array($extraClasses)) {
+            foreach($extraClasses as $value) {
+                if (isset($value['source'])) {
+                    $this->extraFiles[] = $value['source'];
+                }
+            }
+        }
+
+        /**
          * Round 4. Create config.m4 and config.w32 files / Create project.c and project.h files
          */
         $namespace      = str_replace('\\', '_', $namespace);
@@ -1720,6 +1732,22 @@ class Compiler
             $initializers = $invokeInitializers[1];
         }
 
+        /**
+         * Append extra details
+         */
+        $extraClasses = $this->config->get('extra-classes');  
+        if (is_array($extraClasses)) {
+            foreach($extraClasses as $key=>$value) {
+                if (isset($value['init'])) {
+                    $completeClassInits[] = "ZEPHIR_INIT(".$value['init'].")";
+                }
+
+                if (isset($value['entry'])) {
+                    $completeClassEntries[] = "zend_class_entry *".$value['entry'].";";
+                }
+            }
+        }
+
         $toReplace = array(
             '%PROJECT_LOWER_SAFE%'  => strtolower($safeProject),
             '%PROJECT_LOWER%'       => strtolower($project),
@@ -1759,6 +1787,19 @@ class Compiler
                 $fileH = str_replace(".c", ".zep.h", $file);
                 $include = '#include "' . $fileH . '"';
                 $includeHeaders[] = $include;
+            }
+        }
+
+        /**
+         * Append extra headers
+         */
+        $extraClasses = $this->config->get('extra-classes');  
+        if (is_array($extraClasses)) {
+            foreach($extraClasses as $value) {
+                if (isset($value['header'])) {
+                    $include = '#include "' . $value['header'] . '"';
+                    $includeHeaders[] = $include;
+                }
             }
         }
 

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -1737,13 +1737,13 @@ class Compiler
          */
         $extraClasses = $this->config->get('extra-classes');
         if (is_array($extraClasses)) {
-            foreach ($extraClasses as $key=>$value) {
+            foreach ($extraClasses as $value) {
                 if (isset($value['init'])) {
-                    $completeClassInits[] = "ZEPHIR_INIT(".$value['init'].")";
+                    $completeClassInits[] = 'ZEPHIR_INIT(' . $value['init'] . ')';
                 }
 
                 if (isset($value['entry'])) {
-                    $completeClassEntries[] = "zend_class_entry *".$value['entry'].";";
+                    $completeClassEntries[] = 'zend_class_entry *' . $value['entry'] . ';';
                 }
             }
         }


### PR DESCRIPTION
Allow to append custom C classes to extension. Example configuration:

    "extra-classes": {
        "iterator": {
            "source": "own/test/iterator.c",
            "header": "own/test/iterator.h",
            "entry": "own_test_iterator_ce",
            "init": "Own_Test_Iterator"
        }
    }

Is is really important when zephir functionality is not enough.