### PR TITLE
Fix ugly bug inside instanceof

### DIFF
--- a/ext/kernel/object.c
+++ b/ext/kernel/object.c
@@ -89,7 +89,9 @@ int zephir_is_instance_of(zval *object, const char *class_name, unsigned int cla
 
 		ce = Z_OBJCE_P(object);
 		if (ce->name_length == class_length) {
-			return !zend_binary_strcasecmp(ce->name, ce->name_length, class_name, class_length);
+		  	if (!zend_binary_strcasecmp(ce->name, ce->name_length, class_name, class_length)) {
+                            return 1;
+                        }
 		}
 
 		temp_ce = zend_fetch_class(class_name, class_length, ZEND_FETCH_CLASS_DEFAULT TSRMLS_CC);


### PR DESCRIPTION
This function doesn't work properly before change, when compared class name have same length but other content. Now part with Z_OBJCE_P is used only when we compare with same class which is ofcourse faster than zend_fetch_class. Example: 

var a;
let a = new Test();
var_dump(a instanceof Test);