### PR TITLE
Fix annotation parser ignoring character after the star

### DIFF
--- a/Library/Documentation/DocblockParser.php
+++ b/Library/Documentation/DocblockParser.php
@@ -110,12 +110,15 @@ class DocblockParser
                     }
                 } else {
                     if ($currentChar == "*") {
-                        if ($this->nextCharacter() == "/") {
+                        $nextCharacter = $this->nextCharacter();
+                        if ("/" == $nextCharacter) {
                             // stop annotation parsing on end of comment
                             $this->__tryRegisterAnnotation();
                             break;
                         } elseif ($this->ignoreStar) {
-                            $this->nextCharacter();
+                            if ($nextCharacter == " ") {
+                                $this->nextCharacter();
+                            }
                             continue;
                         }
                     }


### PR DESCRIPTION
Annotation parser has issue to parse such a line : https://github.com/phalcon/cphalcon/blob/master/phalcon/acl/adapter/memory.zep#L34

the ``<`` was ignored