### PR TITLE
Fix #994: Make sure to also check the elseif statements for mutations

### DIFF
--- a/Library/Passes/MutateGathererPass.php
+++ b/Library/Passes/MutateGathererPass.php
@@ -299,6 +299,9 @@ class MutateGathererPass
                     if (isset($statement['else_statements'])) {
                         $this->passStatementBlock($statement['else_statements']);
                     }
+                    if (isset($statement['elseif_statements'])) {
+                        $this->passStatementBlock($statement['elseif_statements']);
+                    }
                     break;
 
                 case 'switch':


### PR DESCRIPTION
This was more trivial than expected:

A method cache was used leading to the first constructor being called
multiple times, since elseif branches weren't checked for mutations,
leading to the usage of caches.