### PR TITLE
Rework property initialization to use create_object insteadof constructors

### DIFF
--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -1628,49 +1628,19 @@ class ClassMethod
                 }
             }
         }
-        
-        /**
-         * Set properties of the class, if constructor
-         */
-        $classDefinition = $this->classDefinition;
-        if ($this->isConstructor() || ($this->getName() == 'unserialize' && in_array('Serializable', $classDefinition->getImplementedInterfaces()))) {
-            $initMethod = $classDefinition->getMethod('zephir_init_properties');
-            if ($initMethod && $initMethod->getClassDefinition() == $classDefinition) {
-                $codePrinter->increaseLevel();
-                /* Only initialize properties if the constructor was called directly on the class, e.g. make parent:: calls not trigger property initialization */
-                if ($this->isConstructor()) {
-                    $codePrinter->output('if (EG(called_scope) == '.$classDefinition->getClassEntry().') {');
-                    $codePrinter->increaseLevel();
-                }
-                $codePrinter->output('zephir_init_properties(this_ptr TSRMLS_CC);');
-                if ($this->isConstructor()) {
-                    $codePrinter->decreaseLevel();
-                    $codePrinter->output('}');
-                }
-                $codePrinter->decreaseLevel();
-            }
-            $extendsClass = $classDefinition->getExtendsClassDefinition();
-            $parentConstructor = $extendsClass ? $extendsClass->getMethod('__construct') : null;
-            if ($this->isConstructor() && $extendsClass && $parentConstructor && !$extendsClass->isGeneratedConstructor() && $classDefinition->isGeneratedConstructor()) {
-                /**
-                 * Call the parent constructor (create parent::__construct call)
-                 * since no constructor was actually defined for this class, but
-                 * generated for zephir to ensure property initialization
-                 */
-                $callExpr = new Expression(array(
-                    'type' => 'scall',
-                    'dynamic-class' => 0,
-                    'class' => 'parent',
-                    'dynamic' => 0,
-                    'name' => '__construct',
-                ));
-                $call = new StaticCall();
-                $expr = $callExpr;
-                $expr->setExpectReturn(false);
-                $call->compile($expr, $compilationContext);
-            }
-        }
 
+        /**
+         * Initialize the properties within create_object, handler code
+         */
+        if ($this->getName() == 'zephir_init_properties') {
+            $codePrinter->increaseLevel();
+            $codePrinter->output('{');
+            $codePrinter->increaseLevel();
+            $codePrinter->output('zval *this_ptr = NULL;');
+            $codePrinter->output('ZEPHIR_CREATE_OBJECT(this_ptr, class_type);');
+            $codePrinter->decreaseLevel();
+        }
+        
         /**
          * Compile the block of statements if any
          */
@@ -2287,6 +2257,14 @@ class ClassMethod
             }
         }
 
+        if ($this->getName() == 'zephir_init_properties') {
+            $codePrinter->increaseLevel();
+            $codePrinter->output('return Z_OBJVAL_P(this_ptr);');
+            $codePrinter->decreaseLevel();
+            $codePrinter->output('}');
+            $codePrinter->decreaseLevel();
+        }
+        
         /**
          * Remove macros that grow/restore the memory frame stack if it wasn't used
          */

--- a/Library/ClassProperty.php
+++ b/Library/ClassProperty.php
@@ -255,19 +255,6 @@ class ClassProperty
                 } else {
                     $methodName = 'zephir_init_properties';
                     $visibility = array('internal');
-                    
-                    /* Make sure a constructor exists, so that properties are initialized */
-                    $method = $classDefinition->getMethod('__construct');
-                    if (!$method || $method->getClassDefinition() != $classDefinition) {
-                        $classDefinition->setIsGeneratedConstructor(true);
-                        $classDefinition->getEventsManager()->dispatch('setMethod', array(new ClassMethod(
-                            $classDefinition,
-                            array('public'),
-                            '__construct',
-                            null,
-                            null
-                        ), null));
-                    }
                 }
 
                 $constructParentMethod = null;

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -757,6 +757,22 @@ class Compiler
         }
 
         /**
+         * Sort the files by dependency ranking
+         */
+        $files = array();
+        $rankedFiles = array();
+        $this->calculateDependencies($this->files);
+        foreach ($this->files as $rankFile) {
+            $rank = $rankFile->getClassDefinition()->getDependencyRank();
+            $rankedFiles[$rank][] = $rankFile;
+        }
+        krsort($rankedFiles);
+        foreach ($rankedFiles as $rank => $rankFiles) {
+            $files = array_merge($files, $rankFiles);
+        }
+        $this->files = $files;
+
+        /**
          * Convert C-constants into PHP constants
          */
         $constantsSources = $this->config->get('constants-sources');

--- a/ext/kernel/main.h
+++ b/ext/kernel/main.h
@@ -469,6 +469,22 @@ static inline char *_str_erealloc(char *str, size_t new_len, size_t old_len) {
 		lower_ns## _ ##lcname## _ce->ce_flags |= flags;  \
 	}
 
+#if PHP_VERSION_ID < 50399
+	#define object_properties_init(object, class_type) { \
+		ALLOC_HASHTABLE_REL(object->properties); \
+		zend_hash_init(object->properties, zend_hash_num_elements(&class_type->default_properties), NULL, ZVAL_PTR_DTOR, 0); \
+		zend_hash_copy(object->properties, &class_type->default_properties, (copy_ctor_func_t) zval_add_ref, NULL, sizeof(zval *)); \
+	}
+#endif
+#define ZEPHIR_CREATE_OBJECT(obj_ptr, class_type) \
+	{ \
+		zend_object *object; \
+		ZEPHIR_INIT_ZVAL_NREF(obj_ptr); \
+		Z_TYPE_P(obj_ptr) = IS_OBJECT; \
+		Z_OBJVAL_P(obj_ptr) = zend_objects_new(&object, class_type TSRMLS_CC); \
+		object_properties_init(object, class_type); \
+	}
+
 #define ZEPHIR_REGISTER_INTERFACE(ns, classname, lower_ns, name, methods) \
 	{ \
 		zend_class_entry ce; \


### PR DESCRIPTION
Another step towards consistent constructor (property initialization) behavior:

Effective changes:
------------
- Ensures that classes are compiled in the right dependency order
- The parent constructor generation step is not necessary anymore, since
  property initialization is now in create_object of each class. (before the constructor)
- Allows php defaults (defaults of a PHP class which extends a ZEPHIR class) to overwrite it (except null, which would be tricky with the current
implementation)
- Does remove parent initialization logic if it's anyways overwritten by child initialization
(e.g. parent initializes property ``data`` to an empty array, which then is overwritten to an array containing a string resulted in 2 property assignments, which now results in 1)