### PR TITLE
Fixed ClassMethod::getNumberOfRequiredParameters

### DIFF
--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -577,9 +577,10 @@ class ClassMethod
             if (count($parameters)) {
                 $required = 0;
                 foreach ($parameters as $parameter) {
-                    if (!isset($parameter['default'])) {
-                        $required++;
+                    if (isset($parameter['default']) || (isset($parameter['mandatory']) && !$parameter['mandatory'])) {
+                        continue;
                     }
+                    $required++;
                 }
                 return $required;
             }

--- a/unit-tests/Extension/MCallTest.php
+++ b/unit-tests/Extension/MCallTest.php
@@ -166,7 +166,7 @@ class MCallTest extends \PHPUnit_Framework_TestCase
         $t = new Mcall();
 
         $this->assertNumberOfParameters(1);
-        $this->assertNumberOfRequiredParameters(1);
+        $this->assertNumberOfRequiredParameters(0);
 
         $this->assertTrue($this->getMethodFirstParameter()->isArray());
         $this->assertTrue($t->arrayParam(array()) === array());
@@ -181,7 +181,7 @@ class MCallTest extends \PHPUnit_Framework_TestCase
         $t = new Mcall();
 
         $this->assertNumberOfParameters(1);
-        $this->assertNumberOfRequiredParameters(1);
+        $this->assertNumberOfRequiredParameters(0);
 
         $this->assertSame('stdClass', $this->getMethodFirstParameter()->getClass()->getName());
         $this->assertInstanceOf('stdClass', $t->objectParamCastStdClass(new \stdClass()));
@@ -195,7 +195,7 @@ class MCallTest extends \PHPUnit_Framework_TestCase
         $t = new Mcall();
 
         $this->assertNumberOfParameters(1);
-        $this->assertNumberOfRequiredParameters(1);
+        $this->assertNumberOfRequiredParameters(0);
 
         $this->assertSame('Test\Oo\Param', $this->getMethodFirstParameter()->getClass()->getName());
         $this->assertInstanceOf('Test\Oo\Param', $t->objectParamCastOoParam(new \Test\Oo\Param()));


### PR DESCRIPTION
methods of built-in classes becomes error in check of argument.


ex: test.zep

```
use Phalcon\Mvc\View\Engine;
use Phalcon\Mvc\View\EngineInterface;

class Test extends Engine implements EngineInterface
{
    public function render(string path, var params, boolean mustClean = false)
    { ... }
}
```

execute enerate.

```
$ zephier generate
Zephir\CompilerException: Class Test::partial() does not have the same number of required parameters in interface: Phalcon\Mvc\View\Phalcon\Mvc\View\EngineInterface
```

Phalcon\Mvc\View\EngineInterface

```
public function partial(string! partialPath) -> string;
```

Phalcon\Mvc\View\Engine

```
public function partial(string! partialPath, var params = null) -> string
{ ... } 
```


`ClassDefinition::checkInterfaceImplements`

```
$implementedMethod->getNumberOfRequiredParameters() => 2  # or not properly 1
$method->getNumberOfRequiredParameters() => 1
```
