### PR TITLE
Added extension-name in config.json

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -879,8 +879,12 @@ class Compiler
          * Round 4. Create config.m4 and config.w32 files / Create project.c and project.h files
          */
         $namespace      = str_replace('\\', '_', $namespace);
-        $needConfigure  = $this->createConfigFiles($namespace);
-        $needConfigure |= $this->createProjectFiles($namespace);
+        $extensionName  = $this->config->get('extension-name');
+        if (empty($extensionName) || !is_string($extensionName)) {
+            $extensionName = $namespace;
+        }
+        $needConfigure  = $this->createConfigFiles($extensionName);
+        $needConfigure |= $this->createProjectFiles($extensionName);
         $needConfigure |= $this->checkIfPhpized();
 
         /**


### PR DESCRIPTION
Added extension-name in config.json

To use the same namespace, but want to generate a separate extension.

`config.json`

```
{
  ...
  "namespace": "test",
  "name": "Test",
  "extension-name": "test_a",
  ...
}
```

zephir compile to `ext/modules/test_a.so`.
