### PR TITLE
Fixes docblock

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -355,7 +355,7 @@ class Compiler
      *
      * @param string $className
      *
-     * @return ClassDefinition
+     * @return ClassDefinition|false returns false if no class definition is found
      */
     public function getClassDefinition($className)
     {


### PR DESCRIPTION
getClassDefinition can return false if a class definition is not found.