### PR TITLE
#2308 - Fix support of `string` type in struct globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
+### Fixed
+- Fix support of `string` type in struct globals [#2308](https://github.com/zephir-lang/zephir/issues/2308)
 
 ## [0.15.0] - 2021-10-05
 ### Added

--- a/Library/Code/Builder/Struct.php
+++ b/Library/Code/Builder/Struct.php
@@ -122,6 +122,9 @@ class Struct
             case 'bool':
                 return '';
 
+            case 'string':
+                return "\t".$namespace.'_globals->'.$this->simpleName.'.'.$name.' = ZSTR_VAL(zend_string_init(ZEND_STRL("'.$global['default'].'"), 0));';
+
             case 'int':
             case 'uint':
             case 'long':
@@ -191,6 +194,9 @@ class Struct
 
             case 'hash':
                 return 'HashTable* ';
+
+            case 'string':
+                return 'zend_string* ';
 
             case 'int':
             case 'uint':

--- a/Library/Compiler/CompilerFileFactory.php
+++ b/Library/Compiler/CompilerFileFactory.php
@@ -9,6 +9,8 @@
  * the LICENSE file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Zephir\Compiler;
 
 use Psr\Log\LoggerInterface;
@@ -19,15 +21,12 @@ use Zephir\FileSystem\FileSystemInterface;
 
 final class CompilerFileFactory
 {
-    private $config;
-    private $filesystem;
-    private $logger;
+    private Config $config;
+    private FileSystemInterface $filesystem;
+    private LoggerInterface $logger;
 
-    public function __construct(
-        Config $config,
-        FileSystemInterface $filesystem,
-        LoggerInterface $logger
-    ) {
+    public function __construct(Config $config, FileSystemInterface $filesystem, LoggerInterface $logger)
+    {
         $this->config = $config;
         $this->filesystem = $filesystem;
         $this->logger = $logger;
@@ -43,7 +42,7 @@ final class CompilerFileFactory
      *
      * @return FileInterface
      */
-    public function create($className, $filePath)
+    public function create(string $className, string $filePath): FileInterface
     {
         $compiler = new CompilerFile($this->config, new AliasManager(), $this->filesystem);
 

--- a/config.json
+++ b/config.json
@@ -119,6 +119,10 @@
       "type": "bool",
       "default": true
     },
+    "orm.cache_prefix": {
+      "type": "string",
+      "default": "prefix-string-"
+    },
     "extension.test_ini_variable": {
       "type": "bool",
       "default": true,

--- a/ext/php_stub.h
+++ b/ext/php_stub.h
@@ -26,6 +26,7 @@ typedef struct _zephir_struct_db {
 typedef struct _zephir_struct_orm { 
 	int cache_level;
 	zend_bool cache_enable;
+	zend_string*  cache_prefix;
 } zephir_struct_orm;
 
 typedef struct _zephir_struct_extension { 

--- a/ext/stub.c
+++ b/ext/stub.c
@@ -254,6 +254,7 @@ PHP_INI_BEGIN()
 	
 	
 	STD_PHP_INI_BOOLEAN("stub.orm.cache_enable", "1", PHP_INI_ALL, OnUpdateBool, orm.cache_enable, zend_stub_globals, stub_globals)
+	
 	STD_PHP_INI_BOOLEAN("extension.test_ini_variable", "1", PHP_INI_ALL, OnUpdateBool, extension.test_ini_variable, zend_stub_globals, stub_globals)
 	STD_PHP_INI_BOOLEAN("ini-entry.my_setting_1", "1", PHP_INI_ALL, OnUpdateBool, my_setting_1, zend_stub_globals, stub_globals)
 	STD_PHP_INI_BOOLEAN("stub.test_setting_1", "1", PHP_INI_ALL, OnUpdateBool, test_setting_1, zend_stub_globals, stub_globals)
@@ -520,6 +521,7 @@ static void php_zephir_init_globals(zend_stub_globals *stub_globals)
 	stub_globals->db.my_setting_3 = 7.5;
 	stub_globals->orm.cache_level = 3;
 
+	stub_globals->orm.cache_prefix = ZSTR_VAL(zend_string_init(ZEND_STRL("prefix-string-"), 0));
 
 	stub_globals->my_setting_1 = 1;
 	stub_globals->test_setting_1 = 1;

--- a/ext/stub/globals.zep.c
+++ b/ext/stub/globals.zep.c
@@ -149,6 +149,31 @@ PHP_METHOD(Stub_Globals, setDefaultGlobalsOrmCacheLevel)
 	ZEPHIR_GLOBAL(orm).cache_level = zval_get_long(value);
 }
 
+PHP_METHOD(Stub_Globals, setDefaultGlobalsOrmCachePrefix)
+{
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zval *value_param = NULL;
+	zval value;
+	zval *this_ptr = getThis();
+
+	ZVAL_UNDEF(&value);
+#if PHP_VERSION_ID >= 80000
+	bool is_null_true = 1;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(value)
+	ZEND_PARSE_PARAMETERS_END();
+#endif
+
+
+	ZEPHIR_MM_GROW();
+	zephir_fetch_params(1, 1, 0, &value_param);
+	zephir_get_strval(&value, value_param);
+
+
+	ZEPHIR_GLOBAL(orm).cache_prefix = ZSTR_VAL(zval_get_string(&value));
+	ZEPHIR_MM_RESTORE();
+}
+
 /**
  * @return mixed
  */
@@ -255,5 +280,17 @@ PHP_METHOD(Stub_Globals, getDefaultGlobalsOrmCacheLevel)
 
 
 	RETURN_LONG(ZEPHIR_GLOBAL(orm).cache_level);
+}
+
+/**
+ * @return mixed
+ */
+PHP_METHOD(Stub_Globals, getDefaultGlobalsOrmCachePrefix)
+{
+	zval *this_ptr = getThis();
+
+
+
+	RETURN_STRING(ZEPHIR_GLOBAL(orm).cache_prefix);
 }
 

--- a/ext/stub/globals.zep.h
+++ b/ext/stub/globals.zep.h
@@ -9,6 +9,7 @@ PHP_METHOD(Stub_Globals, setCharValue);
 PHP_METHOD(Stub_Globals, setStringValue);
 PHP_METHOD(Stub_Globals, setBoolValue);
 PHP_METHOD(Stub_Globals, setDefaultGlobalsOrmCacheLevel);
+PHP_METHOD(Stub_Globals, setDefaultGlobalsOrmCachePrefix);
 PHP_METHOD(Stub_Globals, getDefaultGlobals1);
 PHP_METHOD(Stub_Globals, getDefaultGlobals2);
 PHP_METHOD(Stub_Globals, getDefaultGlobals3);
@@ -18,6 +19,7 @@ PHP_METHOD(Stub_Globals, getDefaultGlobals6);
 PHP_METHOD(Stub_Globals, getDefaultGlobals7);
 PHP_METHOD(Stub_Globals, getDefaultGlobals8);
 PHP_METHOD(Stub_Globals, getDefaultGlobalsOrmCacheLevel);
+PHP_METHOD(Stub_Globals, getDefaultGlobalsOrmCachePrefix);
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stub_globals_setboolvalueusingdotnotation, 0, 1, IS_VOID, 0)
 
@@ -49,6 +51,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stub_globals_setdefaultglobalsor
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stub_globals_setdefaultglobalsormcacheprefix, 0, 1, IS_VOID, 0)
+
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_stub_globals_getdefaultglobals1, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -76,6 +83,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_stub_globals_getdefaultglobalsormcachelevel, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_stub_globals_getdefaultglobalsormcacheprefix, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEPHIR_INIT_FUNCS(stub_globals_method_entry) {
 	PHP_ME(Stub_Globals, setBoolValueUsingDotNotation, arginfo_stub_globals_setboolvalueusingdotnotation, ZEND_ACC_PUBLIC)
 	PHP_ME(Stub_Globals, setIntValueUsingDotNotation, arginfo_stub_globals_setintvalueusingdotnotation, ZEND_ACC_PUBLIC)
@@ -83,6 +93,7 @@ ZEPHIR_INIT_FUNCS(stub_globals_method_entry) {
 	PHP_ME(Stub_Globals, setStringValue, arginfo_stub_globals_setstringvalue, ZEND_ACC_PUBLIC)
 	PHP_ME(Stub_Globals, setBoolValue, arginfo_stub_globals_setboolvalue, ZEND_ACC_PUBLIC)
 	PHP_ME(Stub_Globals, setDefaultGlobalsOrmCacheLevel, arginfo_stub_globals_setdefaultglobalsormcachelevel, ZEND_ACC_PUBLIC)
+	PHP_ME(Stub_Globals, setDefaultGlobalsOrmCachePrefix, arginfo_stub_globals_setdefaultglobalsormcacheprefix, ZEND_ACC_PUBLIC)
 #if PHP_VERSION_ID >= 80000
 	PHP_ME(Stub_Globals, getDefaultGlobals1, arginfo_stub_globals_getdefaultglobals1, ZEND_ACC_PUBLIC)
 #else
@@ -127,6 +138,11 @@ ZEPHIR_INIT_FUNCS(stub_globals_method_entry) {
 	PHP_ME(Stub_Globals, getDefaultGlobalsOrmCacheLevel, arginfo_stub_globals_getdefaultglobalsormcachelevel, ZEND_ACC_PUBLIC)
 #else
 	PHP_ME(Stub_Globals, getDefaultGlobalsOrmCacheLevel, NULL, ZEND_ACC_PUBLIC)
+#endif
+#if PHP_VERSION_ID >= 80000
+	PHP_ME(Stub_Globals, getDefaultGlobalsOrmCachePrefix, arginfo_stub_globals_getdefaultglobalsormcacheprefix, ZEND_ACC_PUBLIC)
+#else
+	PHP_ME(Stub_Globals, getDefaultGlobalsOrmCachePrefix, NULL, ZEND_ACC_PUBLIC)
 #endif
 	PHP_FE_END
 };

--- a/stub/globals.zep
+++ b/stub/globals.zep
@@ -35,6 +35,11 @@ class Globals
 		globals_set("orm.cache_level", value);
 	}
 
+	public function setDefaultGlobalsOrmCachePrefix(string value) -> void
+	{
+	    globals_set("orm.cache_prefix", value);
+	}
+
 	/* Get Default Properties */
 
 	/**
@@ -108,4 +113,12 @@ class Globals
 	{
 		return globals_get("orm.cache_level");
 	}
+
+	/**
+     * @return mixed
+     */
+    public function getDefaultGlobalsOrmCachePrefix()
+    {
+        return globals_get("orm.cache_prefix");
+    }
 }

--- a/tests/Extension/GlobalsTest.php
+++ b/tests/Extension/GlobalsTest.php
@@ -83,6 +83,23 @@ final class GlobalsTest extends TestCase
 
         $this->test->setStringValue('Long Text without any sense...');
         $this->assertSame('Long Text without any sense...', $this->test->getDefaultGlobals8());
+
+        /**
+         * Get and set string value from globals struct.
+         */
+        $this->assertSame('prefix-string-', $this->test->getDefaultGlobalsOrmCachePrefix());
+
+        $this->test->setDefaultGlobalsOrmCachePrefix('1');
+        $this->assertSame('1', $this->test->getDefaultGlobalsOrmCachePrefix());
+
+        $this->test->setDefaultGlobalsOrmCachePrefix('c');
+        $this->assertSame('c', $this->test->getDefaultGlobalsOrmCachePrefix());
+
+        $this->test->setDefaultGlobalsOrmCachePrefix('char');
+        $this->assertSame('char', $this->test->getDefaultGlobalsOrmCachePrefix());
+
+        $this->test->setDefaultGlobalsOrmCachePrefix('Long Text without any sense...');
+        $this->assertSame('Long Text without any sense...', $this->test->getDefaultGlobalsOrmCachePrefix());
     }
 
     public function testSetBoolValueUsingInt(): void


### PR DESCRIPTION
Hello!

* Type: bug fix

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Thanks
