### PR TITLE
Corrections for stubs generation with phpstan

### DIFF
--- a/src/Class/Method/Method.php
+++ b/src/Class/Method/Method.php
@@ -1940,7 +1940,7 @@ class Method
      */
     public function getLine(): mixed
     {
-        return $this->expression['line'];
+        return $this->expression['line'] ?? null;
     }
 
     public function getMayBeArgTypes(): array

--- a/src/CompilerFile.php
+++ b/src/CompilerFile.php
@@ -474,13 +474,18 @@ final class CompilerFile implements FileInterface
             $this->classDefinition->getDocBlock(),
             $validator,
             'class ' . $this->classDefinition->getCompleteName(),
+            null,
         );
 
         foreach ($this->classDefinition->getProperties() as $property) {
+            $original = $property->getOriginal();
+            $line     = is_array($original) && isset($original['line']) ? (int) $original['line'] : null;
+
             $this->validateDocblockForPhpStan(
                 $property->getDocBlock(),
                 $validator,
-                'property ' . $property->getName(),
+                'property $' . $property->getName(),
+                $line,
             );
         }
 
@@ -489,22 +494,31 @@ final class CompilerFile implements FileInterface
                 $constant->getDocBlock(),
                 $validator,
                 'constant ' . $constant->getName(),
+                null,
             );
         }
 
         foreach ($this->classDefinition->getMethods() as $method) {
+            $line = $method->getLine();
             $this->validateDocblockForPhpStan(
                 $method->getDocBlock(),
                 $validator,
-                'method ' . $method->getName(),
+                'method ' . $method->getName() . '()',
+                is_int($line) ? $line : null,
             );
         }
     }
 
+    /**
+     * Emits a logger warning for an invalid PHPStan annotation, including
+     * the originating .zep file path and (when available) the line number
+     * of the offending member so the developer can jump straight to it.
+     */
     private function validateDocblockForPhpStan(
         ?string $docBlock,
         \Zephir\Stubs\PhpStanTagValidator $validator,
         string $location,
+        ?int $line,
     ): void {
         if ($docBlock === null || trim($docBlock) === '') {
             return;
@@ -524,8 +538,14 @@ final class CompilerFile implements FileInterface
                 continue;
             }
 
+            $where = $this->filePath;
+            if ($line !== null) {
+                $where .= ':' . $line;
+            }
+
             $this->logger->warning(sprintf(
-                "%s: PHPStan annotation '@%s' has invalid type expression: %s",
+                "%s in %s: PHPStan annotation '@%s' has invalid type expression: %s",
+                $where,
                 $location,
                 $name,
                 $error->message,

--- a/src/Documentation/DocblockParser.php
+++ b/src/Documentation/DocblockParser.php
@@ -24,6 +24,15 @@ use const PHP_EOL;
 class DocblockParser
 {
     protected $annotation;
+    /**
+     * Tracks the depth of brackets/braces/parens/angles opened inside the
+     * current annotation body. Multi-line PHPStan/PSALM annotations
+     * (`@phpstan-type Foo array{...}`, multi-line `@method` signatures,
+     * generic types split across lines, etc.) only terminate when this
+     * counter is back to zero, so newlines inside an unclosed structure
+     * keep accumulating into the same annotation rather than splitting it.
+     */
+    protected $annotationBracketDepth = 0;
     protected $annotationLen;
     protected $annotationNameOpen;
     protected $annotationOpen;
@@ -74,13 +83,14 @@ class DocblockParser
     {
         $this->docblockObj = new Docblock();
 
-        $this->ignoreSpaces       = false;
-        $this->ignoreStar         = true;
-        $this->commentOpen        = false;
-        $this->annotationNameOpen = false;
-        $this->annotationOpen     = false;
-        $this->summaryOpen        = true;
-        $this->descriptionOpen    = false;
+        $this->ignoreSpaces           = false;
+        $this->ignoreStar             = true;
+        $this->commentOpen            = false;
+        $this->annotationNameOpen     = false;
+        $this->annotationOpen         = false;
+        $this->annotationBracketDepth = 0;
+        $this->summaryOpen            = true;
+        $this->descriptionOpen        = false;
 
         $this->currentAnnotationStr        = null;
         $this->currentAnnotationContentStr = null;
@@ -133,9 +143,19 @@ class DocblockParser
                         $this->ignoreSpaces       = false;
                         $this->annotationNameOpen = true;
                     } elseif ($this->annotationNameOpen || $this->annotationOpen) {
-                        // stop annotation parsing on new line
+                        // stop annotation parsing on new line, unless we are
+                        // inside an unclosed bracket/brace/paren/angle (then
+                        // the annotation body keeps growing across lines).
                         if ("\n" == $currentChar || "\r" == $currentChar) {
-                            $this->__tryRegisterAnnotation();
+                            if ($this->annotationOpen && $this->annotationBracketDepth > 0) {
+                                // collapse line break into a single space so
+                                // the downstream type parser sees clean
+                                // whitespace; leading `*` of the next line is
+                                // swallowed by $ignoreStar below.
+                                $this->currentAnnotationContentStr .= ' ';
+                            } else {
+                                $this->__tryRegisterAnnotation();
+                            }
 
                             $this->ignoreSpaces = false;
                             $this->ignoreStar   = true;
@@ -147,6 +167,23 @@ class DocblockParser
                                 $this->currentAnnotationStr .= $currentChar;
                             }
                         } elseif ($this->annotationOpen) {
+                            if (
+                                '{' === $currentChar
+                                || '(' === $currentChar
+                                || '[' === $currentChar
+                                || '<' === $currentChar
+                            ) {
+                                ++$this->annotationBracketDepth;
+                            } elseif (
+                                '}' === $currentChar
+                                || ')' === $currentChar
+                                || ']' === $currentChar
+                                || '>' === $currentChar
+                            ) {
+                                if ($this->annotationBracketDepth > 0) {
+                                    --$this->annotationBracketDepth;
+                                }
+                            }
                             $this->currentAnnotationContentStr .= $currentChar;
                         }
                     } elseif ($this->summaryOpen) {
@@ -220,8 +257,9 @@ class DocblockParser
             $this->docblockObj->addAnnotation($annotation);
         }
 
-        $this->annotationNameOpen = false;
-        $this->annotationOpen     = false;
+        $this->annotationNameOpen     = false;
+        $this->annotationOpen         = false;
+        $this->annotationBracketDepth = 0;
     }
 
     /**

--- a/src/Stubs/MethodDocBlock.php
+++ b/src/Stubs/MethodDocBlock.php
@@ -82,12 +82,42 @@ class MethodDocBlock extends DocBlock
 
     /**
      * Parse DocBlock and returns extracted groups.
+     *
+     * The `type` group is matched non-greedily and accepts any non-whitespace
+     * payload, then optionally followed by `$name`. This deliberately tolerates
+     * modern PHPDoc/PHPStan/Psalm type syntax — generics (`array<int|string,
+     * mixed>`), array shapes (`array{key: string}`), nullable / union /
+     * intersection (`?int`, `Foo|Bar`, `Foo&Bar`), callable signatures
+     * (`callable(int): bool`), and chained brackets (`Foo[]`) — without
+     * enumerating each shape in the regex. When `$name` is absent (e.g.
+     * `@return Foo`), the optional group is skipped and the entire trailing
+     * remainder is treated as the type.
      */
     protected function parseDocBlockParam(string $line): array
     {
+        // The `type` alternation extends the original word/union/array-bracket
+        // grammar with three more block forms commonly used by modern PHPDoc
+        // dialects:
+        //   - `<...>` for generic types  : `array<int|string, mixed>`
+        //   - `{...}` for array shapes   : `array{key: string, ...}`
+        //   - `(...)` for callable arglists / grouped unions
+        // Each block is non-nesting (one level only); annotations with nested
+        // generics like `array<array<int>>` are rare in zephir source and can
+        // still fall back to the catch-all description capture if not parsed.
         $pattern = '~
             @(?P<doctype>param|return|var)\s+
-            (?P<type>[\\\\\w]+(:?\s*\|\s*[\\\\\w]+|\s*\[]+)*)\s*
+            (?P<type>
+                \?? [\\\\\w]+
+                (?:
+                    \s*\|\s*\?? [\\\\\w]+
+                    | \s*&\s*\?? [\\\\\w]+
+                    | \s*\[]+
+                    | < [^<>]* >
+                    | \{ [^{}]* \}
+                    | \( [^()]* \)
+                    | :\s*[\\\\\w|]+
+                )*
+            )\s*
             (?P<dollar>\$)?
             (?P<name>[a-z_][a-z0-9_]*)?\s*
             (?P<description>(.|\s)*)?

--- a/tests/Zephir/Documentation/DocblockParserTest.php
+++ b/tests/Zephir/Documentation/DocblockParserTest.php
@@ -76,4 +76,209 @@ final class DocblockParserTest extends TestCase
         $this->assertEquals($expected->getAnnotationsByType('param'), $actual->getAnnotationsByType('param'));
         $this->assertEquals($expected->getAnnotationsByType('return'), $actual->getAnnotationsByType('return'));
     }
+
+    /**
+     * A PHPStan type-alias whose body is a multi-line array shape must be
+     * captured as a single annotation; the newline between `array{` and the
+     * following members is inside an unclosed brace and therefore should
+     * not terminate annotation parsing.
+     */
+    public function testShouldParseMultiLinePhpStanTypeAliasAcrossNewlines(): void
+    {
+        if (Os::isWindows()) {
+            $this->markTestSkipped('Warning: Strings contain different line endings!');
+        }
+
+        $test = <<<DOC
+            /**
+             * Component description.
+             *
+             * @phpstan-type TTemplate array{
+             *      main: string,
+             *      line: string,
+             *      last: string
+             *  }
+             */
+            DOC;
+
+        $parser = new DocblockParser($test);
+        $parser->parse();
+        $actual = $parser->getParsedDocblock();
+
+        $annotations = $actual->getAnnotationsByType('phpstan-type');
+        $this->assertCount(1, $annotations);
+        // Indentation from continuation lines is preserved verbatim; the
+        // newline itself collapses to a single space. Assert via
+        // whitespace-normalized comparison so the test stays robust against
+        // future indentation tweaks in the heredoc above.
+        $this->assertSame(
+            'TTemplate array{ main: string, line: string, last: string }',
+            preg_replace('/\s+/', ' ', $annotations[0]->getString())
+        );
+    }
+
+    /**
+     * Two consecutive multi-line PHPStan type aliases must register as two
+     * independent annotations; closing the first `array{...}` must reset
+     * bracket-depth tracking so the second alias is not absorbed into the
+     * first.
+     */
+    public function testShouldParseTwoConsecutiveMultiLinePhpStanTypeAliases(): void
+    {
+        if (Os::isWindows()) {
+            $this->markTestSkipped('Warning: Strings contain different line endings!');
+        }
+
+        $test = <<<DOC
+            /**
+             * @phpstan-type TTemplate array{
+             *      main: string,
+             *      line: string
+             *  }
+             * @phpstan-type TElement array{
+             *      attributes: array<string, string>,
+             *      icon: string,
+             *      link: string
+             *  }
+             */
+            DOC;
+
+        $parser = new DocblockParser($test);
+        $parser->parse();
+        $actual = $parser->getParsedDocblock();
+
+        $annotations = $actual->getAnnotationsByType('phpstan-type');
+        $this->assertCount(2, $annotations);
+        $this->assertSame(
+            'TTemplate array{ main: string, line: string }',
+            preg_replace('/\s+/', ' ', $annotations[0]->getString())
+        );
+        $this->assertSame(
+            'TElement array{ attributes: array<string, string>, icon: string, link: string }',
+            preg_replace('/\s+/', ' ', $annotations[1]->getString())
+        );
+    }
+
+    /**
+     * Multi-line `@method` signature whose parameter list spans several
+     * lines must remain a single annotation; the open `(` keeps the
+     * annotation alive across newlines until the matching `)` is seen.
+     */
+    public function testShouldParseMultiLineMethodSignatureAcrossNewlines(): void
+    {
+        if (Os::isWindows()) {
+            $this->markTestSkipped('Warning: Strings contain different line endings!');
+        }
+
+        $test = <<<DOC
+            /**
+             * @method Result handle(
+             *      string \$name,
+             *      array \$options,
+             *      ?int \$flags = null
+             *  )
+             */
+            DOC;
+
+        $parser = new DocblockParser($test);
+        $parser->parse();
+        $actual = $parser->getParsedDocblock();
+
+        $annotations = $actual->getAnnotationsByType('method');
+        $this->assertCount(1, $annotations);
+        $this->assertSame(
+            'Result handle( string $name, array $options, ?int $flags = null )',
+            preg_replace('/\s+/', ' ', $annotations[0]->getString())
+        );
+    }
+
+    /**
+     * Multi-line generic type wrapped across several lines must keep the
+     * annotation open until the closing `>` brings the depth counter back
+     * to zero.
+     */
+    public function testShouldParseMultiLineGenericTypeAcrossNewlines(): void
+    {
+        if (Os::isWindows()) {
+            $this->markTestSkipped('Warning: Strings contain different line endings!');
+        }
+
+        $test = <<<DOC
+            /**
+             * @param array<
+             *      int,
+             *      string
+             *  > \$rows
+             */
+            DOC;
+
+        $parser = new DocblockParser($test);
+        $parser->parse();
+        $actual = $parser->getParsedDocblock();
+
+        $annotations = $actual->getAnnotationsByType('param');
+        $this->assertCount(1, $annotations);
+        $this->assertSame(
+            'array< int, string > $rows',
+            preg_replace('/\s+/', ' ', $annotations[0]->getString())
+        );
+    }
+
+    /**
+     * Regression guard: a plain single-line annotation must still terminate
+     * on the first newline even though bracket-depth tracking is now in
+     * place. The new logic only suppresses termination when depth > 0.
+     */
+    public function testShouldStillTerminateSingleLineAnnotationOnNewline(): void
+    {
+        if (Os::isWindows()) {
+            $this->markTestSkipped('Warning: Strings contain different line endings!');
+        }
+
+        $test = <<<DOC
+            /**
+             * @param array \$rows the dataset
+             * @return void
+             */
+            DOC;
+
+        $parser = new DocblockParser($test);
+        $parser->parse();
+        $actual = $parser->getParsedDocblock();
+
+        $params = $actual->getAnnotationsByType('param');
+        $returns = $actual->getAnnotationsByType('return');
+
+        $this->assertCount(1, $params);
+        $this->assertCount(1, $returns);
+        $this->assertSame('array $rows the dataset', $params[0]->getString());
+        $this->assertSame('void', $returns[0]->getString());
+    }
+
+    /**
+     * Stray closing brackets (no matching opener) must not push
+     * `annotationBracketDepth` below zero. The depth counter is floored
+     * at zero, so a `}` outside any open structure leaves termination
+     * behavior unchanged for the next annotation.
+     */
+    public function testShouldHandleStrayClosingBracketsWithoutLockingAnnotation(): void
+    {
+        if (Os::isWindows()) {
+            $this->markTestSkipped('Warning: Strings contain different line endings!');
+        }
+
+        $test = <<<DOC
+            /**
+             * @param string \$json closing brace inside text: }
+             * @return void
+             */
+            DOC;
+
+        $parser = new DocblockParser($test);
+        $parser->parse();
+        $actual = $parser->getParsedDocblock();
+
+        $this->assertCount(1, $actual->getAnnotationsByType('param'));
+        $this->assertCount(1, $actual->getAnnotationsByType('return'));
+    }
 }

--- a/tests/Zephir/Stubs/MethodDocBlockTest.php
+++ b/tests/Zephir/Stubs/MethodDocBlockTest.php
@@ -239,6 +239,45 @@ final class MethodDocBlockTest extends TestCase
                 // php
                 '@param Foo[] $name - some description',
             ],
+            'with PHPStan generic type' => [
+                // Zep
+                '@param array<int|string, mixed> $data',
+                // Php — verbatim round-trip; no duplicate @param appended
+                // because the regex now captures `<...>` blocks inside the
+                // type group so $data is properly registered as the param
+                // name.
+                '@param array<int|string, mixed> $data',
+            ],
+            'with PHPStan array shape' => [
+                // Zep
+                '@param array{key: string, value: int} $row',
+                // Php
+                '@param array{key: string, value: int} $row',
+            ],
+            'with nullable prefix' => [
+                // Zep
+                '@param ?int $count - optional count',
+                // Php
+                '@param ?int $count - optional count',
+            ],
+            'with intersection types' => [
+                // Zep
+                '@param Foo&Bar $thing',
+                // Php
+                '@param Foo&Bar $thing',
+            ],
+            'with callable signature' => [
+                // Zep
+                '@param callable(int, string): bool $cb',
+                // Php
+                '@param callable(int, string): bool $cb',
+            ],
+            'generic-only return without name' => [
+                // Zep
+                '@return array<int, string>',
+                // Php
+                '@return array<int, string>',
+            ],
         ];
     }
 


### PR DESCRIPTION
Hello!

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I updated the CHANGELOG


Stubs: 


Corrections on how zephir stubs handles PHPStan directives.
Increased readability on array shapes 