### PR TITLE
feat(github): add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yaml
@@ -1,0 +1,62 @@
+name: "Bug Report"
+description: "Create a report to help us improve"
+labels: ["Type: Bug", "need triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: Version of Zephir and PHP
+      placeholder: |
+        - Zephir 0.y.z
+        - PHP 8.y.z
+        - OS: Linux / macOS / Windows
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "Describe what you wanted to do."
+      placeholder: |
+        I am trying to test...
+        I executed the following command...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: "Reproduction"
+      description: "Provide a code snippet that causes the error."
+      placeholder: |
+        With the following code:
+        ```zep
+        class Foo {
+            public function bar()
+            {
+                // ...
+            }
+        }
+        ```
+        Here is the message from the console
+        ```
+        Error: ...
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected"
+      description: "Explain what you expected."
+      placeholder: "I expected the Foo class to..."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_template.yaml
@@ -1,0 +1,30 @@
+name: "Feature request"
+description: "Suggest an idea for this project "
+labels: ["Type: Feature", "Status: Need Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest an idea for this project
+
+  - type: textarea
+    id: feature
+    attributes:
+      label: "Feature"
+      description: "What problem does this solve? How does this improve Zephir?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: "Example"
+      description: "Describe the solution you'd like"
+      placeholder: |
+        ```php
+        <?php
+
+        // Code example
+        ```
+    validations:
+      required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 ### Added
-- Add two templates to structure bug reports and feature requests.
+- Add two templates to structure bug reports and feature requests. [#2525](https://github.com/zephir-lang/zephir/pull/2525)
 - Added `<self>` method return-type annotation being emitted as a namespaced literal class name in arginfo: `ArgInfoDefinition::richRenderStart()` passed every class-typed return through `getFullName()`, so a method declared with `-> <self>` produced `ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(..., Stub\self, ...)`. `Reflection::getReturnType()->getName()` consequently reported `Stub\self` instead of the reserved keyword `self`, and PHP-side subclass return covariance against `: self` could not work. `self`, `static`, and `parent` are now passed through to the engine unprefixed and lowercased (matching PHP's reserved type-name handling). Companion grammar change in `php-zephir-parser` adds a `<static>` cast/return-type rule (the `STATIC` token is reserved and never reached the `IDENTIFIER`-based cast rule), so `-> <static>` now parses and produces a `cast.value = "static"` AST node. End-to-end this enables late-static-binding return types: a subclass calling a parent method declared `-> <static>` receives an instance of the subclass, and reflection reports the reserved `static` keyword. [#2505](https://github.com/zephir-lang/zephir/issues/2505)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 ### Added
+- Add two templates to structure bug reports and feature requests.
 - Added `<self>` method return-type annotation being emitted as a namespaced literal class name in arginfo: `ArgInfoDefinition::richRenderStart()` passed every class-typed return through `getFullName()`, so a method declared with `-> <self>` produced `ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(..., Stub\self, ...)`. `Reflection::getReturnType()->getName()` consequently reported `Stub\self` instead of the reserved keyword `self`, and PHP-side subclass return covariance against `: self` could not work. `self`, `static`, and `parent` are now passed through to the engine unprefixed and lowercased (matching PHP's reserved type-name handling). Companion grammar change in `php-zephir-parser` adds a `<static>` cast/return-type rule (the `STATIC` token is reserved and never reached the `IDENTIFIER`-based cast rule), so `-> <static>` now parses and produces a `cast.value = "static"` AST node. End-to-end this enables late-static-binding return types: a subclass calling a parent method declared `-> <static>` receives an instance of the subclass, and reflection reports the reserved `static` keyword. [#2505](https://github.com/zephir-lang/zephir/issues/2505)
 
 ### Fixed


### PR DESCRIPTION
Add two templates to structure bug reports and feature requests.
It will help structure and guide feedback from the community.

- [ ] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I updated the CHANGELOG

## Result

<img width="858" height="291" alt="image" src="https://github.com/user-attachments/assets/9a78759b-5dbf-4bdf-96af-8a622fa6c00d" />
