### PR TITLE
#2435 - Implement deferred validation for `use` statements to prevent false warnings

### DIFF
--- a/src/CompilerFile.php
+++ b/src/CompilerFile.php
@@ -88,6 +88,17 @@ final class CompilerFile implements FileInterface
     private ?string $namespace = null;
 
     /**
+     * `use` statements as parsed from the IR — kept around so
+     * checkDependencies() can validate their FQCNs after every file in the
+     * extension has been preCompiled (preCompile order is alphabetical, so
+     * an in-extension class referenced by a use in an earlier-sorted file
+     * isn't yet registered when that file is being preCompiled).
+     *
+     * @var array<int, array>
+     */
+    private array $useStatements = [];
+
+    /**
      * @var mixed
      */
     private $originalNode;
@@ -145,6 +156,38 @@ final class CompilerFile implements FileInterface
     public function checkDependencies(Compiler $compiler): void
     {
         $classDefinition = $this->classDefinition;
+
+        /**
+         * Validate `use Foo\Bar` FQCNs now that every file in the extension
+         * has been preCompiled — intra-extension classes are guaranteed to
+         * be in $compiler->isClass()/isInterface() at this point.
+         *
+         * @see https://github.com/zephir-lang/zephir/issues/2435.
+         */
+        foreach ($this->useStatements as $useStatement) {
+            foreach ($useStatement['aliases'] as $useAlias) {
+                $fqcn = $useAlias['name'];
+                if (
+                    $compiler->isClass($fqcn)
+                    || $compiler->isInterface($fqcn)
+                    || $compiler->isBundledClass($fqcn)
+                    || $compiler->isBundledInterface($fqcn)
+                    || class_exists($fqcn, false)
+                    || interface_exists($fqcn, false)
+                    || trait_exists($fqcn, false)
+                ) {
+                    continue;
+                }
+
+                $this->logger->warning(
+                    sprintf(
+                        'Class or interface "%s" used in `use` statement does not exist at compile time',
+                        $fqcn
+                    ),
+                    ['nonexistent-class', $useAlias]
+                );
+            }
+        }
 
         $extendedClass = $classDefinition->getExtendsClass();
         if ($extendedClass) {
@@ -717,40 +760,17 @@ final class CompilerFile implements FileInterface
                     $this->aliasManager->add($topStatement);
 
                     /**
-                     * Validate that each `use Foo\Bar` references an existing
-                     * class/interface/trait. Without this check, typos in the
-                     * FQCN flow through silently and surface at runtime as the
-                     * opaque "Fatal error: During class fetch" — the user has
-                     * to bisect their code to find the misspelled `use`. Same
-                     * `nonexistent-class` warning channel that `extends`,
-                     * `implements`, `new ClassName()` and `obj->method()` use,
-                     * so the existing `-Wno-nonexistent-class` opt-out works
-                     * for any legitimate runtime-only class references.
+                     * Defer FQCN existence validation to checkDependencies() —
+                     * preCompile() is per-file, so an in-extension class
+                     * referenced via `use` from a file that sorts earlier
+                     * than the class's own file is not yet registered with
+                     * $compiler when we'd check here. checkDependencies()
+                     * runs after every file has been preCompiled, with the
+                     * full intra-extension class table populated.
                      *
                      * @see https://github.com/zephir-lang/zephir/issues/2435.
                      */
-                    foreach ($topStatement['aliases'] as $useAlias) {
-                        $fqcn = $useAlias['name'];
-                        if (
-                            $compiler->isClass($fqcn)
-                            || $compiler->isInterface($fqcn)
-                            || $compiler->isBundledClass($fqcn)
-                            || $compiler->isBundledInterface($fqcn)
-                            || class_exists($fqcn, false)
-                            || interface_exists($fqcn, false)
-                            || trait_exists($fqcn, false)
-                        ) {
-                            continue;
-                        }
-
-                        $this->logger->warning(
-                            sprintf(
-                                'Class or interface "%s" used in `use` statement does not exist at compile time',
-                                $fqcn
-                            ),
-                            ['nonexistent-class', $useAlias]
-                        );
-                    }
+                    $this->useStatements[] = $topStatement;
                     break;
 
                 case 'comment':

--- a/tests/Zephir/BlackBox/UseStatementValidationTest.php
+++ b/tests/Zephir/BlackBox/UseStatementValidationTest.php
@@ -90,6 +90,41 @@ ZEP);
         $this->assertStringNotContainsString('does not exist at compile time', $output);
     }
 
+    public function testIntraExtensionUseDoesNotWarn(): void
+    {
+        // Regression: file alphabetical order forces the importing file
+        // (`aconsumer.zep`) to be preCompiled BEFORE the file declaring the
+        // imported class (`zlater.zep`). Validation must run after every
+        // file has been preCompiled, not per-file at parse time, otherwise
+        // legitimate intra-extension `use` statements falsely warn.
+        $this->writeZep('aconsumer.zep', <<<'ZEP'
+namespace Stub;
+
+use Stub\ZLater;
+
+class AConsumer
+{
+    public function noop(<ZLater> z)
+    {
+    }
+}
+ZEP);
+        $this->writeZep('zlater.zep', <<<'ZEP'
+namespace Stub;
+
+class ZLater
+{
+}
+ZEP);
+
+        $result = $this->runZephir('generate --no-ansi', $this->projectDir);
+
+        $this->assertSame(0, $result['exitCode']);
+        $output = $result['stdout'] . $result['stderr'];
+        $this->assertStringNotContainsString('Stub\\ZLater', $output);
+        $this->assertStringNotContainsString('does not exist at compile time', $output);
+    }
+
     public function testWnoFlagSuppressesTheWarning(): void
     {
         $this->writeZep('typo.zep', <<<'ZEP'


### PR DESCRIPTION
Hello!

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I updated the CHANGELOG
