### PR TITLE
Fix: cross-class chained `<static>` returns resolve against receiver, not call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 - Compiler now recognizes the parser-emitted `yield` AST node (bare `yield;`, `yield expr;`, `yield key, value;`) [#1849](https://github.com/zephir-lang/zephir/issues/1849)
 
+### Fixed
+- Fixed cross-class chained `<static>` (and `<self>`/`<parent>`) return-type resolution. The same-class case landed in #2537 by substituting the lexical class for the reserved keyword. The cross-class case — `other->returnsStatic()->method()` where `other` is a local variable typed as a different class — was still resolved against the call site's lexical class, so the chained method lookup ran on the wrong definition and the build aborted with `Class '<EnclosingClass>' does not implement method: '<method>'`. `MethodCall.php` already resolves the receiver's `$classDefinition` earlier in the function (from `$variableVariable->getClassTypes()`); the substitution now uses that definition, which is identical to `$compilationContext->classDefinition` for the `this` branch and preserves existing behavior there. [#2505](https://github.com/zephir-lang/zephir/issues/2505)
+
 ### Documentation
 - Documented the workaround for `[ClassName, "protectedOrPrivateMethod"]` arrays passed as callbacks to PHP higher-order functions (`array_reduce`, `usort`, `preg_replace_callback`, etc.) [#2167](https://github.com/zephir-lang/zephir/issues/2167)
 

--- a/src/MethodCall.php
+++ b/src/MethodCall.php
@@ -572,27 +572,33 @@ class MethodCall extends Call
 
                 if (null !== $returnClassTypes) {
                     $symbolVariable->setDynamicTypes('object');
+                    /*
+                     * `self`, `static`, and `parent` resolve relative to the
+                     * RECEIVER of the call, not the lexical class of the
+                     * call site. For `this->returnsStatic()` the two are the
+                     * same (handled at the top of this method where
+                     * `$classDefinition` was assigned from
+                     * `$compilationContext->classDefinition`). For
+                     * `other->returnsStatic()->chain()` they differ:
+                     * `$classDefinition` already carries the receiver's
+                     * class (resolved earlier from
+                     * `$variableVariable->getClassTypes()`), and that is
+                     * what `self`/`static`/`parent` must rewrite to so the
+                     * chained method lookup happens on the right class.
+                     * Using `$compilationContext->classDefinition` here
+                     * makes the chained call look up the method on the
+                     * enclosing class instead, producing a spurious
+                     * "Class '<enclosing>' does not implement method ..."
+                     * error.
+                     * See https://github.com/zephir-lang/zephir/issues/2505.
+                     */
+                    $receiverDefinition = $classDefinition ?? $compilationContext->classDefinition;
                     foreach ($returnClassTypes as &$returnClassType) {
-                        /*
-                         * `self`, `static` and `parent` are PHP-reserved type
-                         * names; resolve them to the *lexical* class (for
-                         * `self`/`static`) or the parent class (for `parent`)
-                         * so compile-time method lookup on a chained call
-                         * `obj->returnsStatic()->method()` finds the right
-                         * class definition. Passing them through getFullName()
-                         * would produce a bogus literal like `Stub\static`
-                         * that fails class lookup and emits a false-positive
-                         * `nonexistent-class` warning. The runtime LSB binding
-                         * is unaffected — that's still handled by
-                         * `zend_get_called_scope(execute_data)` in
-                         * NewInstanceOperator. See
-                         * https://github.com/zephir-lang/zephir/issues/2505.
-                         */
                         $lower = strtolower($returnClassType);
                         if ($lower === 'self' || $lower === 'static') {
-                            $returnClassType = $compilationContext->classDefinition->getCompleteName();
+                            $returnClassType = $receiverDefinition->getCompleteName();
                         } elseif ($lower === 'parent') {
-                            $parent = $compilationContext->classDefinition->getExtendsClass();
+                            $parent = $receiverDefinition->getExtendsClass();
                             if ($parent !== null && $parent !== '') {
                                 $returnClassType = $parent;
                             }

--- a/stub/issue2505crosschain.zep
+++ b/stub/issue2505crosschain.zep
@@ -1,0 +1,33 @@
+namespace Stub;
+
+/**
+ * Regression coverage for the cross-class chained `<static>` resolution.
+ *
+ * A method declared `-> <static>` on `Issue2505` is called via a LOCAL
+ * variable (not `this`), and the result is immediately chained. Before
+ * the fix, `MethodCall.php` resolved `<static>` to the LEXICAL class of
+ * the call site (i.e. `Stub\Issue2505CrossChain`) instead of the
+ * receiver's class (`Stub\Issue2505`). Compile-time method lookup for
+ * `checkPrivate()` then ran against `Issue2505CrossChain` — which has
+ * no such method — and the build aborted with:
+ *
+ *     Class 'Stub\Issue2505CrossChain' does not implement method: 'checkPrivate'
+ *
+ * After the fix, `static`/`self`/`parent` resolve against the receiver's
+ * class definition (the one already used to look up the called method),
+ * so the chained lookup correctly finds `Issue2505::checkPrivate()`.
+ *
+ * @see https://github.com/zephir-lang/zephir/issues/2505
+ */
+class Issue2505CrossChain
+{
+    public function crossClassChain(<Issue2505> instance) -> bool
+    {
+        return instance->makeStatic()->checkPrivate();
+    }
+
+    public function crossClassChainSelf(<Issue2505> instance) -> bool
+    {
+        return instance->makeSelf()->checkPrivate();
+    }
+}

--- a/tests/Extension/Issue2505Test.php
+++ b/tests/Extension/Issue2505Test.php
@@ -16,6 +16,7 @@ namespace Extension;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Stub\Issue2505;
+use Stub\Issue2505CrossChain;
 use Stub\Issue2505Extended;
 
 /**
@@ -102,5 +103,29 @@ final class Issue2505Test extends TestCase
     {
         $this->assertTrue(method_exists(Issue2505::class, 'chainedStatic'));
         $this->assertTrue(method_exists(Issue2505::class, 'chainedSelf'));
+    }
+
+    /**
+     * Compile-time regression for cross-class chained `<static>` resolution.
+     *
+     * `Issue2505CrossChain::crossClassChain()` chains `checkPrivate()` on the
+     * `<static>` return of `Issue2505::makeStatic()`. Before the fix,
+     * `MethodCall.php` resolved `static` to the lexical class
+     * (`Issue2505CrossChain`) instead of the receiver's class (`Issue2505`),
+     * so compile-time method lookup aborted with
+     * "Class 'Stub\Issue2505CrossChain' does not implement method:
+     * 'checkPrivate'". The presence and runtime correctness of these methods
+     * in the compiled stub asserts the fix.
+     */
+    public function testCrossClassChainedStaticResolvesToReceiver(): void
+    {
+        $sut = new Issue2505CrossChain();
+        $this->assertTrue($sut->crossClassChain(new Issue2505()));
+    }
+
+    public function testCrossClassChainedSelfResolvesToReceiver(): void
+    {
+        $sut = new Issue2505CrossChain();
+        $this->assertTrue($sut->crossClassChainSelf(new Issue2505()));
     }
 }


### PR DESCRIPTION
Hello!

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Follow-up to #2537. The previous fix correctly handled the same-class chained case (`this->returnsStatic()->method()`) by substituting the lexical class for `self`/`static`/`parent` in `MethodCall.php`. It did not cover the **cross-class** chain:

```zephir
public function crossClassChain(<Issue2505> instance) -> bool
{
    return instance->makeStatic()->checkPrivate();
}
```
  
Here static must resolve to the receiver's class (Issue2505), not the lexical class of the call site (Issue2505CrossChain). The old code aborted with:

`Class 'Stub\Issue2505CrossChain' does not implement method: 'checkPrivate'`

### Fix

`MethodCall.php` already resolves the receiver's `$classDefinition` earlier in the function (from `$variableVariable->getClassTypes()`). Use it - instead of `$compilationContext->classDefinition` - when substituting reserved type names in chained return types. For the this branch the two are identical, so existing behavior is preserved.

### Test plan

New fixture `stub/issue2505crosschain.zep` declares a chain whose compile-time success is the regression assertion; without the fix, code generation aborts with the error above. Two new test cases in Issue2505Test exercise both `<static>` and `<self>` cross-class chains and assert the runtime result.
