### PR TITLE
#2274 - Depreate `!` (strict type) in args types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Changed
 - The `ext-zephir_parser` C extension is now **optional**: it is used as a fast path when loaded, otherwise the built-in PHP parser handles parsing. Set the `ZEPHIR_FORCE_PHP_PARSER` environment variable to force the PHP backend even when the extension is present (useful for differential testing and deterministic builds). `Zephir\Parser\Manager::isAvailable()` is now always `true` [#2495](https://github.com/zephir-lang/zephir/issues/2495)
 
+### Deprecated
+- The `!` (strict type) modifier on argument types (e.g. `int! a`) now emits a deprecation notice during `zephir generate`. A future parser will no longer recognize it. Suppress with `-Wdeprecated-strict-type` [#2274](https://github.com/zephir-lang/zephir/issues/2274)
+
 ## [0.23.0] - 2026-06-06
 
 ### Added

--- a/src/Class/Method/Method.php
+++ b/src/Class/Method/Method.php
@@ -1362,27 +1362,27 @@ class Method
             }
 
             /**
-             * Emit deprecation warning for string! parameters.
-             * Z_PARAM_STR already enforces strict string typing at the
-             * engine level, making the ! modifier redundant.
+             * Emit a deprecation notice for every `!` (strict type) parameter.
+             * PHP now enforces scalar argument types itself, so the `!` modifier
+             * is redundant and will be removed; a future parser will no longer
+             * recognize it (see #2274, precursor to #2275).
              */
             foreach ($this->parameters->getParameters() as $parameter) {
                 if (!empty($parameter['variadic'])) {
                     continue;
                 }
-                $paramMandatory = $parameter['mandatory'] ?? 0;
-                $paramDataType  = $this->getParamDataType($parameter);
-                if ($paramMandatory && $paramDataType === 'string') {
+                if ($parameter['mandatory'] ?? 0) {
                     $compilationContext->logger->warning(
                         sprintf(
-                            "The '!' (strict) modifier on string parameter '%s' is deprecated "
-                            . "and will be removed in a future version. String parameters are "
-                            . "now strict by default via Z_PARAM_STR in %s::%s",
+                            "The '!' (strict type) modifier on parameter '%s' (%s) is deprecated "
+                            . "and will be removed; the parser will no longer recognize it in a "
+                            . "future version. Remove the '!' in %s::%s",
                             $parameter['name'],
+                            $this->getParamDataType($parameter),
                             $this->getClassDefinition()?->getCompleteName() ?? '[unknown]',
                             $this->getName()
                         ),
-                        ['deprecated-strict-string', $parameter]
+                        ['deprecated-strict-type', $parameter]
                     );
                 }
             }

--- a/src/Config.php
+++ b/src/Config.php
@@ -96,6 +96,7 @@ class Config implements ArrayAccess, JsonSerializable
             'invalid-reference'                  => true,
             'invalid-typeof-comparison'          => true,
             'conditional-initialization'         => true,
+            'deprecated-strict-type'             => true,
         ],
         'optimizations' => [
             'static-type-inference'             => true,

--- a/tests/Zephir/BlackBox/DeprecatedStrictTypeTest.php
+++ b/tests/Zephir/BlackBox/DeprecatedStrictTypeTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Zephir\Test\BlackBox;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The `!` (strict type) modifier on an argument type is redundant now that PHP
+ * enforces scalar argument types itself. `zephir generate` must emit a
+ * deprecation notice for every `!`-typed parameter, regardless of the data type,
+ * telling the author to remove it before a future parser stops recognizing it.
+ *
+ * @see https://github.com/zephir-lang/zephir/issues/2274
+ */
+final class DeprecatedStrictTypeTest extends TestCase
+{
+    use RunsZephirCommands;
+
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $this->setUpZephirRunner();
+
+        $this->projectDir = sys_get_temp_dir() . '/zephir-strict-' . bin2hex(random_bytes(6));
+        $this->cleanupPath($this->projectDir);
+        mkdir($this->projectDir . '/stub', 0777, true);
+        file_put_contents(
+            $this->projectDir . '/config.json',
+            json_encode(['namespace' => 'stub', 'name' => 'stub'])
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownZephirRunner();
+    }
+
+    public function testStrictIntParameterEmitsDeprecation(): void
+    {
+        $this->writeZep('strictint.zep', <<<'ZEP'
+namespace Stub;
+
+class StrictInt
+{
+    public function run(int! value)
+    {
+    }
+}
+ZEP);
+
+        $result = $this->runZephir('generate --no-ansi', $this->projectDir);
+
+        $this->assertSame(0, $result['exitCode']);
+        $output = $result['stdout'] . $result['stderr'];
+        $this->assertStringContainsString('deprecated-strict-type', $output);
+        $this->assertStringContainsString("'value'", $output);
+    }
+
+    public function testStrictStringParameterEmitsDeprecation(): void
+    {
+        $this->writeZep('strictstr.zep', <<<'ZEP'
+namespace Stub;
+
+class StrictStr
+{
+    public function run(string! value)
+    {
+    }
+}
+ZEP);
+
+        $result = $this->runZephir('generate --no-ansi', $this->projectDir);
+
+        $this->assertSame(0, $result['exitCode']);
+        $this->assertStringContainsString(
+            'deprecated-strict-type',
+            $result['stdout'] . $result['stderr']
+        );
+    }
+
+    public function testNonStrictParameterEmitsNoDeprecation(): void
+    {
+        $this->writeZep('plain.zep', <<<'ZEP'
+namespace Stub;
+
+class Plain
+{
+    public function run(int value)
+    {
+    }
+}
+ZEP);
+
+        $result = $this->runZephir('generate --no-ansi', $this->projectDir);
+
+        $this->assertSame(0, $result['exitCode']);
+        $this->assertStringNotContainsString(
+            'deprecated-strict-type',
+            $result['stdout'] . $result['stderr']
+        );
+    }
+
+    public function testDeprecationCanBeSuppressed(): void
+    {
+        $this->writeZep('suppress.zep', <<<'ZEP'
+namespace Stub;
+
+class Suppress
+{
+    public function run(int! value)
+    {
+    }
+}
+ZEP);
+
+        $result = $this->runZephir('generate --no-ansi -Wdeprecated-strict-type', $this->projectDir);
+
+        $this->assertSame(0, $result['exitCode']);
+        $this->assertStringNotContainsString(
+            'deprecated-strict-type',
+            $result['stdout'] . $result['stderr']
+        );
+    }
+
+    private function writeZep(string $relativePath, string $content): void
+    {
+        $full = $this->projectDir . '/stub/' . $relativePath;
+        if (!is_dir(dirname($full))) {
+            mkdir(dirname($full), 0777, true);
+        }
+        file_put_contents($full, $content);
+    }
+}

--- a/tests/Zephir/BlackBox/RunsZephirCommands.php
+++ b/tests/Zephir/BlackBox/RunsZephirCommands.php
@@ -76,23 +76,39 @@ trait RunsZephirCommands
             $args,
         );
 
+        // Redirect the child's stdout/stderr to temp files instead of pipes.
+        // Draining pipes sequentially (stdout to EOF, then stderr) deadlocks on
+        // Windows once either stream exceeds the ~4 KB pipe buffer: the child
+        // blocks writing the not-yet-read stream while the parent blocks reading
+        // the other. Files have no such limit and yield identical bytes on every
+        // platform.
+        $stdoutFile = tempnam(sys_get_temp_dir(), 'zephir-out');
+        $stderrFile = tempnam(sys_get_temp_dir(), 'zephir-err');
+
         $descriptors = [
             0 => ['pipe', 'r'],
-            1 => ['pipe', 'w'],
-            2 => ['pipe', 'w'],
+            1 => ['file', $stdoutFile, 'w'],
+            2 => ['file', $stderrFile, 'w'],
         ];
 
         $process = proc_open($command, $descriptors, $pipes, $cwd ?: null);
         if (!is_resource($process)) {
+            @unlink($stdoutFile);
+            @unlink($stderrFile);
+
             return ['exitCode' => -1, 'stdout' => '', 'stderr' => 'Failed to start process'];
         }
 
-        fclose($pipes[0]);
-        $stdout = stream_get_contents($pipes[1]);
-        $stderr = stream_get_contents($pipes[2]);
-        fclose($pipes[1]);
-        fclose($pipes[2]);
+        if (isset($pipes[0])) {
+            fclose($pipes[0]);
+        }
         $exitCode = proc_close($process);
+
+        $stdout = file_get_contents($stdoutFile);
+        $stderr = file_get_contents($stderrFile);
+
+        @unlink($stdoutFile);
+        @unlink($stderrFile);
 
         return [
             'exitCode' => $exitCode,


### PR DESCRIPTION
Hello!

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG
