### PR TITLE
Adding detection for traits during compilation - removes warning

### DIFF
--- a/src/CompilerFile.php
+++ b/src/CompilerFile.php
@@ -159,8 +159,9 @@ final class CompilerFile implements FileInterface
 
         /**
          * Validate `use Foo\Bar` FQCNs now that every file in the extension
-         * has been preCompiled — intra-extension classes are guaranteed to
-         * be in $compiler->isClass()/isInterface() at this point.
+         * has been preCompiled — intra-extension classes, interfaces and
+         * traits are guaranteed to be in
+         * $compiler->isClass()/isInterface()/isTrait() at this point.
          *
          * @see https://github.com/zephir-lang/zephir/issues/2435.
          */
@@ -170,6 +171,7 @@ final class CompilerFile implements FileInterface
                 if (
                     $compiler->isClass($fqcn)
                     || $compiler->isInterface($fqcn)
+                    || $compiler->isTrait($fqcn)
                     || $compiler->isBundledClass($fqcn)
                     || $compiler->isBundledInterface($fqcn)
                     || class_exists($fqcn, false)


### PR DESCRIPTION
Hello!

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

A warning is emitted when compiling code with traits. This PR removes that